### PR TITLE
Simplified voter

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ Adds extra features to eZ Publish 5.4 / eZ Platform.
 
   Lets you define a theme fallback order for your templates, similar to
   [legacy design fallback system](https://doc.ez.no/eZ-Publish/Technical-manual/5.x/Concepts-and-basics/Designs/Design-combinations).
+  
+* **[Simplified authorization checks](Resources/doc/simplified_auth_checks.md)**
+
+  Simplifies calls to `$this->isGranted()` from inside controllers and `is_granted()` from within templates when checking
+  against eZ inner permission system (module/function/valueObject).
 
 ## Requirements
 EzCoreExtraBundle currently works with **eZ Publish 5.4/2014.11** (and *should work* with Netgen variant)

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -38,3 +38,11 @@ services:
             - [setContextAwareGlobals, ["$twig_globals;ez_core_extra$"]]
         tags:
             - { name: twig.extension }
+
+    ez_core_extra.security.simplified_core_voter:
+        class: Lolautruche\EzCoreExtraBundle\Security\Voter\SimplifiedCoreVoter
+        arguments:
+            - "@ezpublish.security.voter.core"
+            - "@ezpublish.security.voter.value_object"
+        tags:
+            - { name: "security.voter" }

--- a/Resources/doc/simplified_auth_checks.md
+++ b/Resources/doc/simplified_auth_checks.md
@@ -1,0 +1,73 @@
+# Simplified authorization checks
+
+This feature simplifies the way you check authorization with eZ inner ACL system, using
+`module/function` and optionnaly a value object (e.g. a content object).
+
+Without eZCoreExtraBundle, when one want to check if a user has access to a module/function like
+`content/read`, they have to implement the following in their controller:
+
+```php
+namespace Acme\Controller;
+
+use eZ\Bundle\EzPublishCoreBundle\Controller;
+use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute as AuthorizationAttribute;
+
+class MyController extends Controller
+{
+    public function fooAction()
+    {
+        // ...
+        $accessGranted = $this->isGranted(new AuthorizationAttribute('content', 'read'));
+        
+        // Or with an actual content
+        $accessGranted = $this->isGranted(
+            new AuthorizationAttribute('content', 'read', ['valueObject' => $myContent])
+        );
+    }
+}
+```
+
+While this is efficient, it is a bit cumbersome to write.
+Furthermore, it's not possible to do such security checks within Twig templates, as it's not possible
+to instantiate new objects from there.
+
+EzCoreExtraBundle adds a new simplified syntax for such checks, usable in templates.
+
+## Usage
+In order to check access for a `module`/`function` pair, instead of instantiating an `AuthorizationAttribute`
+object, just use the following syntax:
+
+```
+ez:<module>:<function>
+```
+
+Taking the example from the introduction, it will be:
+
+```php
+namespace Acme\Controller;
+
+use eZ\Bundle\EzPublishCoreBundle\Controller;
+
+class MyController extends Controller
+{
+    public function fooAction()
+    {
+        // ...
+        $accessGranted = $this->isGranted('ez:content:read');
+        
+        // Or with an actual content
+        $accessGranted = $this->isGranted('ez:content:read', $myContent);
+    }
+}
+```
+
+In a template, the syntax will be:
+
+```jinja
+{% set accessGranted = is_granted('ez:content:read') %}
+
+{# Or with an actual content #}
+{% set accessGranted = is_granted('ez:content:read', my_content) %}
+```
+
+Et voilà :-)

--- a/Security/Voter/SimplifiedCoreVoter.php
+++ b/Security/Voter/SimplifiedCoreVoter.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the EzCoreExtraBundle package.
+ *
+ * (c) Jérôme Vieilledent <jerome@vieilledent.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Lolautruche\EzCoreExtraBundle\Security\Voter;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute as AuthorizationAttribute;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+class SimplifiedCoreVoter implements VoterInterface
+{
+    const EZ_ROLE_PREFIX = 'ez:';
+
+    /**
+     * @var VoterInterface
+     */
+    private $coreVoter;
+
+    /**
+     * @var VoterInterface
+     */
+    private $valueObjectVoter;
+
+    public function __construct(VoterInterface $coreVoter, VoterInterface $valueObjectVoter)
+    {
+        $this->coreVoter = $coreVoter;
+        $this->valueObjectVoter = $valueObjectVoter;
+    }
+
+    public function supportsAttribute($attribute)
+    {
+        return is_string($attribute) && stripos($attribute, static::EZ_ROLE_PREFIX) === 0;
+    }
+
+    public function supportsClass($class)
+    {
+        return true;
+    }
+
+    public function vote(TokenInterface $token, $object, array $attributes)
+    {
+        foreach ($attributes as $attribute) {
+            if (!$this->supportsAttribute($attribute)) {
+                continue;
+            }
+
+            $attribute = substr($attribute, strlen(static::EZ_ROLE_PREFIX));
+            list($module, $function) = explode(':', $attribute);
+            $attributeObject = new AuthorizationAttribute($module, $function);
+            if ($object instanceof ValueObject) {
+                $attributeObject->limitations = ['valueObject' => $object];
+                return $this->valueObjectVoter->vote($token, $object, [$attributeObject]);
+            } else {
+                return $this->coreVoter->vote($token, $object, [$attributeObject]);
+            }
+        }
+
+        return static::ACCESS_ABSTAIN;
+    }
+}

--- a/Tests/Asset/AssetPathResolverTest.php
+++ b/Tests/Asset/AssetPathResolverTest.php
@@ -19,7 +19,7 @@ class AssetPathResolverTest extends PHPUnit_Framework_TestCase
 {
     public function testResolveAssetPathFail()
     {
-        $logger = $this->getMock('\Psr\Log\LoggerInterface');
+        $logger = $this->createMock('\Psr\Log\LoggerInterface');
         $logger
             ->expects($this->once())
             ->method('warning');

--- a/Tests/Asset/ThemePackageTest.php
+++ b/Tests/Asset/ThemePackageTest.php
@@ -30,8 +30,8 @@ class ThemePackageTest extends PHPUnit_Framework_TestCase
     {
         parent::setUp();
 
-        $this->assetPathResolver = $this->getMock('\Lolautruche\EzCoreExtraBundle\Asset\AssetPathResolverInterface');
-        $this->innerPackage = $this->getMock('\Symfony\Component\Asset\PackageInterface');
+        $this->assetPathResolver = $this->createMock('\Lolautruche\EzCoreExtraBundle\Asset\AssetPathResolverInterface');
+        $this->innerPackage = $this->createMock('\Symfony\Component\Asset\PackageInterface');
     }
 
     public function testGetUrl()

--- a/Tests/EventListener/ViewTemplateListenerTest.php
+++ b/Tests/EventListener/ViewTemplateListenerTest.php
@@ -34,7 +34,7 @@ class ViewTemplateListenerTest extends PHPUnit_Framework_TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->configResolver = $this->getMock('\eZ\Publish\Core\MVC\ConfigResolverInterface');
+        $this->configResolver = $this->createMock('\eZ\Publish\Core\MVC\ConfigResolverInterface');
         $this->dynamicSettingParser = new DynamicSettingParser();
     }
 
@@ -55,9 +55,9 @@ class ViewTemplateListenerTest extends PHPUnit_Framework_TestCase
     {
         // \eZ\Publish\Core\MVC\Symfony\View\View is only defined in kernel >=6.0
         if (interface_exists('\eZ\Publish\Core\MVC\Symfony\View\View')) {
-            $view = $this->getMock('\eZ\Publish\Core\MVC\Symfony\View\View');
+            $view = $this->createMock('\eZ\Publish\Core\MVC\Symfony\View\View');
         } else {
-            $view = $this->getMock('\eZ\Publish\Core\MVC\Symfony\View\ContentViewInterface');
+            $view = $this->createMock('\eZ\Publish\Core\MVC\Symfony\View\ContentViewInterface');
         }
 
         return $view;
@@ -161,7 +161,7 @@ class ViewTemplateListenerTest extends PHPUnit_Framework_TestCase
         $event = new PreContentViewEvent($view);
 
         $providerAlias = 'some_provider';
-        $provider = $this->getMock('\Lolautruche\EzCoreExtraBundle\Templating\ViewParameterProviderInterface');
+        $provider = $this->createMock('\Lolautruche\EzCoreExtraBundle\Templating\ViewParameterProviderInterface');
         $listener = new ViewTemplateListener($this->configResolver, $this->dynamicSettingParser);
         $listener->addParameterProvider($provider, $providerAlias);
 

--- a/Tests/Security/Voter/SimplifiedCoreVoterTest.php
+++ b/Tests/Security/Voter/SimplifiedCoreVoterTest.php
@@ -1,0 +1,156 @@
+<?php
+
+/*
+ * This file is part of the EzCoreExtraBundle package.
+ *
+ * (c) Jérôme Vieilledent <jerome@vieilledent.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Lolautruche\EzCoreExtraBundle\Tests\Security\Voter;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute;
+use Lolautruche\EzCoreExtraBundle\Security\Voter\SimplifiedCoreVoter;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+class SimplifiedCoreVoterTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|VoterInterface
+     */
+    private $coreVoter;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|VoterInterface
+     */
+    private $valueObjectVoter;
+
+    /**
+     * @var SimplifiedCoreVoter
+     */
+    private $voter;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->coreVoter = $this->createMock(VoterInterface::class);
+        $this->valueObjectVoter = $this->createMock(VoterInterface::class);
+        $this->voter = new SimplifiedCoreVoter($this->coreVoter, $this->valueObjectVoter);
+    }
+
+    /**
+     * @dataProvider supportsAttributeProvider
+     */
+    public function testSupportsAttribute($attribute, $expectedResult)
+    {
+        $this->assertSame($expectedResult, $this->voter->supportsAttribute($attribute));
+    }
+
+    public function supportsAttributeProvider()
+    {
+        return [
+            ['foo', false],
+            ['bar', false],
+            [SimplifiedCoreVoter::EZ_ROLE_PREFIX.'foo:bar', true],
+            [new \stdClass(), false],
+            [[], false]
+        ];
+    }
+
+    public function testVoteNotSupportedAttribute()
+    {
+        $this->assertSame(
+            VoterInterface::ACCESS_ABSTAIN,
+            $this->voter->vote($this->createMock(TokenInterface::class), null, ['foo'])
+        );
+    }
+
+    public function testVoteGrantedNoValueObject()
+    {
+        $token = $this->createMock(TokenInterface::class);
+        $object = null;
+        $attribute = 'ez:foo:bar';
+        $attributeObject = new Attribute('foo', 'bar');
+        $this->coreVoter
+            ->expects($this->once())
+            ->method('vote')
+            ->with($token, $object, [$attributeObject])
+            ->willReturn(VoterInterface::ACCESS_GRANTED);
+        $this->valueObjectVoter
+            ->expects($this->never())
+            ->method('vote');
+
+        $this->assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $this->voter->vote($token, $object, [$attribute])
+        );
+    }
+
+    public function testVoteDeniedNoValueObject()
+    {
+        $token = $this->createMock(TokenInterface::class);
+        $object = null;
+        $attribute = 'ez:foo:bar';
+        $attributeObject = new Attribute('foo', 'bar');
+        $this->coreVoter
+            ->expects($this->once())
+            ->method('vote')
+            ->with($token, $object, [$attributeObject])
+            ->willReturn(VoterInterface::ACCESS_DENIED);
+        $this->valueObjectVoter
+            ->expects($this->never())
+            ->method('vote');
+
+        $this->assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $this->voter->vote($token, $object, [$attribute])
+        );
+    }
+
+    public function testVoteGrantedWithValueObject()
+    {
+        $token = $this->createMock(TokenInterface::class);
+        $object = $this->createMock(ValueObject::class);
+        $attribute = 'ez:foo:bar';
+        $attributeObject = new Attribute('foo', 'bar', ['valueObject' => $object]);
+        $this->valueObjectVoter
+            ->expects($this->once())
+            ->method('vote')
+            ->with($token, $object, [$attributeObject])
+            ->willReturn(VoterInterface::ACCESS_GRANTED);
+        $this->coreVoter
+            ->expects($this->never())
+            ->method('vote');
+
+        $this->assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $this->voter->vote($token, $object, [$attribute])
+        );
+    }
+
+    public function testVoteDeniedWithValueObject()
+    {
+        $token = $this->createMock(TokenInterface::class);
+        $object = $this->createMock(ValueObject::class);
+        $attribute = 'ez:foo:bar';
+        $attributeObject = new Attribute('foo', 'bar', ['valueObject' => $object]);
+        $this->valueObjectVoter
+            ->expects($this->once())
+            ->method('vote')
+            ->with($token, $object, [$attributeObject])
+            ->willReturn(VoterInterface::ACCESS_DENIED);
+        $this->coreVoter
+            ->expects($this->never())
+            ->method('vote');
+
+        $this->assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $this->voter->vote($token, $object, [$attribute])
+        );
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "psr-4": {"Lolautruche\\EzCoreExtraBundle\\": ""}
     },
     "require-dev": {
+        "phpunit/phpunit": "^5.4",
         "mikey179/vfsStream": "^1.6.3"
     }
 }


### PR DESCRIPTION
# Simplified authorization checks

This feature simplifies the way you check authorization with eZ inner ACL system, using
`module/function` and optionnaly a value object (e.g. a content object).

Without eZCoreExtraBundle, when one want to check if a user has access to a module/function like
`content/read`, they have to implement the following in their controller:

``` php
namespace Acme\Controller;

use eZ\Bundle\EzPublishCoreBundle\Controller;
use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute as AuthorizationAttribute;

class MyController extends Controller
{
    public function fooAction()
    {
        // ...
        $accessGranted = $this->isGranted(new AuthorizationAttribute('content', 'read'));

        // Or with an actual content
        $accessGranted = $this->isGranted(
            new AuthorizationAttribute('content', 'read', ['valueObject' => $myContent])
        );
    }
}
```

While this is efficient, it is a bit cumbersome to write.
Furthermore, it's not possible to do such security checks within Twig templates, as it's not possible
to instantiate new objects from there.

EzCoreExtraBundle adds a new simplified syntax for such checks, usable in templates.
## Usage

In order to check access for a `module`/`function` pair, instead of instantiating an `AuthorizationAttribute`
object, just use the following syntax:

```
ez:<module>:<function>
```

Taking the example from the introduction, it will be:

``` php
namespace Acme\Controller;

use eZ\Bundle\EzPublishCoreBundle\Controller;

class MyController extends Controller
{
    public function fooAction()
    {
        // ...
        $accessGranted = $this->isGranted('ez:content:read');

        // Or with an actual content
        $accessGranted = $this->isGranted('ez:content:read', $myContent);
    }
}
```

In a template, the syntax will be:

``` jinja
{% set accessGranted = is_granted('ez:content:read') %}

{# Or with an actual content #}
{% set accessGranted = is_granted('ez:content:read', my_content) %}
```

Et voilà :-)
