### PR TITLE
Added PHPStorm goto support for theme templates

### DIFF
--- a/DependencyInjection/Compiler/PHPStormPass.php
+++ b/DependencyInjection/Compiler/PHPStormPass.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the EzCoreExtraBundle package.
+ *
+ * (c) Jérôme Vieilledent <jerome@vieilledent.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Lolautruche\EzCoreExtraBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Filesystem\Filesystem;
+
+class PHPStormPass implements CompilerPassInterface
+{
+    private $projectRootDir;
+
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->getParameter('ez_core_extra.phpstorm.enabled')) {
+            return;
+        }
+
+        if (!$container->hasParameter('ez_core_extra.themes.path_map')) {
+            return;
+        }
+
+        $pathConfig = [];
+        $twigConfigPath = realpath($container->getParameter('ez_core_extra.phpstorm.twig_config_path'));
+        foreach ($container->getParameter('ez_core_extra.themes.path_map') as $theme => $paths) {
+            foreach ($paths as $path) {
+                if ($theme !== '_override') {
+                    $pathConfig[] = [
+                        'namespace' => $theme,
+                        'path' => $this->makeTwigPathRelative($path, $twigConfigPath),
+                    ];
+                }
+
+                $pathConfig[] = [
+                    'namespace' => 'ezdesign',
+                    'path' => $this->makeTwigPathRelative($path, $twigConfigPath),
+                ];
+            }
+        }
+
+        (new Filesystem())->dumpFile(
+            $twigConfigPath.'/ide-twig.json',
+            json_encode(['namespaces' => $pathConfig], JSON_UNESCAPED_SLASHES)
+        );
+    }
+
+    /**
+     * Converts absolute $path to a path relative to ide-twig.json config file.
+     *
+     * @param string $path Absolute path
+     * @param string $configPath Absolute path where ide-twig.json is stored
+     * @return string
+     */
+    private function makeTwigPathRelative($path, $configPath)
+    {
+        return trim(str_replace($configPath, '', $path), '/');
+    }
+}

--- a/DependencyInjection/Compiler/TwigThemePass.php
+++ b/DependencyInjection/Compiler/TwigThemePass.php
@@ -52,7 +52,7 @@ class TwigThemePass implements CompilerPassInterface
             }
 
             /** @var \Symfony\Component\Finder\SplFileInfo $directoryInfo */
-            foreach ($finder->directories()->in($themeDir) as $directoryInfo) {
+            foreach ($finder->directories()->in($themeDir)->depth('== 0') as $directoryInfo) {
                 $themesPathMap[$directoryInfo->getBasename()][] = $directoryInfo->getRealPath();
             }
         }
@@ -68,6 +68,9 @@ class TwigThemePass implements CompilerPassInterface
             if (is_dir($overrideThemeDir)) {
                 array_unshift($paths, $overrideThemeDir);
             }
+
+            // De-duplicate the map
+            $themesPathMap[$theme] = array_unique($themesPathMap[$theme]);
         }
 
         foreach ($container->getParameter('ez_core_extra.themes.design_list') as $designName => $themeFallback) {

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -40,6 +40,16 @@ class Configuration extends SiteAccessConfiguration
                         ->end()
                     ->end()
                 ->end()
+                ->arrayNode('phpstorm')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->booleanNode('enabled')->defaultValue('%kernel.debug%')->info('Activates PHPStorm support')->end()
+                        ->scalarNode('twig_config_path')
+                            ->info('Path where to store PHPStorm configuration file for additional Twig namespaces (ide-twig.json).')
+                            ->defaultValue('%kernel.root_dir%/..')
+                        ->end()
+                    ->end()
+                ->end()
             ->end();
 
         $systemNode = $this->generateScopeBaseNode($rootNode);

--- a/DependencyInjection/EzCoreExtraExtension.php
+++ b/DependencyInjection/EzCoreExtraExtension.php
@@ -45,6 +45,10 @@ class EzCoreExtraExtension extends Extension implements PrependExtensionInterfac
         $container->setParameter('ez_core_extra.themes.design_list', $config['design']['list']);
         $container->setParameter('ez_core_extra.themes.override_paths', $config['design']['override_paths']);
 
+        // PHPStorm settings
+        $container->setParameter('ez_core_extra.phpstorm.enabled', $config['phpstorm']['enabled']);
+        $container->setParameter('ez_core_extra.phpstorm.twig_config_path', $config['phpstorm']['twig_config_path']);
+
         // SiteAccess aware settings
         $processor->mapConfig(
             $config,

--- a/EzCoreExtraBundle.php
+++ b/EzCoreExtraBundle.php
@@ -13,7 +13,9 @@ namespace Lolautruche\EzCoreExtraBundle;
 
 use Lolautruche\EzCoreExtraBundle\DependencyInjection\Compiler\AssetThemePass;
 use Lolautruche\EzCoreExtraBundle\DependencyInjection\Compiler\ParameterProviderPass;
+use Lolautruche\EzCoreExtraBundle\DependencyInjection\Compiler\PHPStormPass;
 use Lolautruche\EzCoreExtraBundle\DependencyInjection\Compiler\TwigThemePass;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -25,5 +27,6 @@ class EzCoreExtraBundle extends Bundle
         $container->addCompilerPass(new ParameterProviderPass());
         $container->addCompilerPass(new TwigThemePass());
         $container->addCompilerPass(new AssetThemePass());
+        $container->addCompilerPass(new PHPStormPass(), PassConfig::TYPE_OPTIMIZE);
     }
 }

--- a/Resources/doc/themes.md
+++ b/Resources/doc/themes.md
@@ -99,6 +99,30 @@ ez_core_extra:
 
 > `app/Resources/views/` will **always** be the top level override directory.
 
+#### PHPStorm support
+`@ezdesign` Twig namespace is a *virtual* namespace, and as such is not automatically recognized by PHPStorm Symfony plugin 
+for `goto` actions.
+
+EzCoreExtraBundle will generate a `ide-twig.json` file which will contain all detected theme paths for templates in your project.
+It's activated by default in debug mode (`%kernel.debug%`).
+
+By default, this config file will be stored at your project root (`%kernel.root_dir%/..`), but you can customize the path 
+if your PHPStorm project root doesn't match your Symfony project root.
+
+> Note: `ide-twig.json` **must** be stored at your PHPStorm project root.
+
+Default config:
+```yaml
+ez_core_extra:
+    phpstorm:
+
+        # Activates PHPStorm support
+        enabled:              '%kernel.debug%'
+
+        # Path where to store PHPStorm configuration file for additional Twig namespaces (ide-twig.json).
+        twig_config_path:     '%kernel.root_dir%/..'
+```
+
 ### Assets
 For assets, a special `ezdesign` asset package is available.
 


### PR DESCRIPTION
`@ezdesign` Twig namespace is a *virtual* namespace, and as such is not automatically recognized by PHPStorm Symfony plugin 
for `goto` actions.

EzCoreExtraBundle will generate a `ide-twig.json` file which will contain all detected theme paths for templates in your project.
It's activated by default in debug mode (`%kernel.debug%`).

By default, this config file will be stored at your project root (`%kernel.root_dir%/..`), but you can customize the path if your PHPStorm project root doesn't match your Symfony project root.

> Note: `ide-twig.json` **must** be stored at your PHPStorm project root.

Default config:
```yaml
ez_core_extra:
    phpstorm:

        # Activates PHPStorm support
        enabled:              '%kernel.debug%'

        # Path where to store PHPStorm configuration file for additional Twig namespaces (ide-twig.json).
        twig_config_path:     '%kernel.root_dir%/..'
```