### PR TITLE
Fix #16: Incompatibility with Twig 2.0.0

### DIFF
--- a/DependencyInjection/Compiler/TwigThemePass.php
+++ b/DependencyInjection/Compiler/TwigThemePass.php
@@ -92,14 +92,23 @@ class TwigThemePass implements CompilerPassInterface
         $container->setParameter('ez_core_extra.themes.path_map', $themesPathMap);
 
         // Override Twig environment
+        $isTwigLegacy = version_compare(\Twig_Environment::VERSION, '2.0.0', '<');
         $twigDef = $container->findDefinition('twig');
         $twigDef->addMethodCall('setTemplateNameResolver', [new Reference('ez_core_extra.template_name_resolver')]);
         $twigDef->addMethodCall('setKernelRootDir', [$container->getParameter('kernel.root_dir')]);
         // Different base class for Twig environment depending if legacy is present/activated or not
         if ($container->hasParameter('ezpublish_legacy.enabled') && $container->getParameter('ezpublish_legacy.enabled')) {
-            $twigDef->setClass('Lolautruche\EzCoreExtraBundle\Templating\Twig\LegacyBasedTwigEnvironment');
+            if ($isTwigLegacy) {
+                $twigDef->setClass('Lolautruche\EzCoreExtraBundle\Templating\Twig\LegacyBasedTwigLegacyEnvironment');
+            } else {
+                $twigDef->setClass('Lolautruche\EzCoreExtraBundle\Templating\Twig\LegacyBasedTwigEnvironment');
+            }
         } else {
-            $twigDef->setClass('Lolautruche\EzCoreExtraBundle\Templating\Twig\TwigEnvironment');
+            if ($isTwigLegacy) {
+                $twigDef->setClass('Lolautruche\EzCoreExtraBundle\Templating\Twig\TwigLegacyEnvironment');
+            } else {
+                $twigDef->setClass('Lolautruche\EzCoreExtraBundle\Templating\Twig\TwigEnvironment');
+            }
         }
     }
 }

--- a/Templating/Twig/LegacyBasedTwigEnvironment.php
+++ b/Templating/Twig/LegacyBasedTwigEnvironment.php
@@ -12,16 +12,16 @@
 namespace Lolautruche\EzCoreExtraBundle\Templating\Twig;
 
 use eZ\Publish\Core\MVC\Legacy\Templating\Twig\Environment as LegacyTwigEnvironment;
-use Lolautruche\EzCoreExtraBundle\Templating\Twig\TwigEnvironmentTrait;
+use Twig_Source;
 
 class LegacyBasedTwigEnvironment extends LegacyTwigEnvironment
 {
     use TwigEnvironmentTrait;
 
-    public function compileSource($source, $name = null)
+    public function compileSource(Twig_Source $source)
     {
         $this->addPathMapping($source);
 
-        return parent::compileSource($source, $name);
+        return parent::compileSource($source);
     }
 }

--- a/Templating/Twig/LegacyBasedTwigLegacyEnvironment.php
+++ b/Templating/Twig/LegacyBasedTwigLegacyEnvironment.php
@@ -11,17 +11,17 @@
 
 namespace Lolautruche\EzCoreExtraBundle\Templating\Twig;
 
-use Twig_Environment;
-use Twig_Source;
+use eZ\Publish\Core\MVC\Legacy\Templating\Twig\Environment as LegacyTwigEnvironment;
+use Lolautruche\EzCoreExtraBundle\Templating\Twig\TwigEnvironmentTrait;
 
-class TwigEnvironment extends Twig_Environment
+class LegacyBasedTwigLegacyEnvironment extends LegacyTwigEnvironment
 {
     use TwigEnvironmentTrait;
 
-    public function compileSource(Twig_Source $source)
+    public function compileSource($source, $name = null)
     {
         $this->addPathMapping($source);
 
-        return parent::compileSource($source);
+        return parent::compileSource($source, $name);
     }
 }

--- a/Templating/Twig/TwigLegacyEnvironment.php
+++ b/Templating/Twig/TwigLegacyEnvironment.php
@@ -11,17 +11,17 @@
 
 namespace Lolautruche\EzCoreExtraBundle\Templating\Twig;
 
+use Lolautruche\EzCoreExtraBundle\Templating\Twig\TwigEnvironmentTrait;
 use Twig_Environment;
-use Twig_Source;
 
-class TwigEnvironment extends Twig_Environment
+class TwigLegacyEnvironment extends Twig_Environment
 {
     use TwigEnvironmentTrait;
 
-    public function compileSource(Twig_Source $source)
+    public function compileSource($source, $name = null)
     {
         $this->addPathMapping($source);
 
-        return parent::compileSource($source);
+        return parent::compileSource($source, $name);
     }
 }


### PR DESCRIPTION
Adds `TwigLegacyEnvironment` and `LegacyBasedTwigLegacyEnvironment` for BC with Twig 1.x