### PR TITLE
Fix #20: Fatal if global themes directories don't exist

### DIFF
--- a/DependencyInjection/Compiler/AssetThemePass.php
+++ b/DependencyInjection/Compiler/AssetThemePass.php
@@ -49,12 +49,14 @@ class AssetThemePass implements CompilerPassInterface
 
         // Look for assets themes at application level (web/assets/themes).
         $appLevelThemeDir = $container->getParameter('webroot_dir').'/assets/themes';
-        foreach ((new Finder())->directories()->in($appLevelThemeDir)->depth('== 0') as $directoryInfo) {
-            $theme = $directoryInfo->getBasename();
-            $themePaths = isset($themesPathMap[$theme]) ? $themesPathMap[$theme] : [];
-            // Application level paths are always top priority.
-            array_unshift($themePaths, 'assets/themes/'.$theme);
-            $themesPathMap[$theme] = $themePaths;
+        if (is_dir($appLevelThemeDir)) {
+            foreach ((new Finder())->directories()->in($appLevelThemeDir)->depth('== 0') as $directoryInfo) {
+                $theme = $directoryInfo->getBasename();
+                $themePaths = isset($themesPathMap[$theme]) ? $themesPathMap[$theme] : [];
+                // Application level paths are always top priority.
+                array_unshift($themePaths, 'assets/themes/'.$theme);
+                $themesPathMap[$theme] = $themePaths;
+            }
         }
 
         foreach ($themesPathMap as $theme => &$paths) {

--- a/DependencyInjection/Compiler/TwigThemePass.php
+++ b/DependencyInjection/Compiler/TwigThemePass.php
@@ -60,12 +60,14 @@ class TwigThemePass implements CompilerPassInterface
         $twigLoaderDef = $container->findDefinition('ez_core_extra.twig_theme_loader');
         // Now look for themes at application level (app/Resources/views/themes)
         $appLevelThemesDir = $globalViewsDir.'/themes';
-        foreach ((new Finder())->directories()->in($appLevelThemesDir)->depth('== 0') as $directoryInfo) {
-            $theme = $directoryInfo->getBasename();
-            $themePaths = isset($themesPathMap[$theme]) ? $themesPathMap[$theme] : [];
-            // Application level paths are always top priority.
-            array_unshift($themePaths, $directoryInfo->getRealPath());
-            $themesPathMap[$theme] = $themePaths;
+        if (is_dir($appLevelThemesDir)) {
+            foreach ((new Finder())->directories()->in($appLevelThemesDir)->depth('== 0') as $directoryInfo) {
+                $theme = $directoryInfo->getBasename();
+                $themePaths = isset($themesPathMap[$theme]) ? $themesPathMap[$theme] : [];
+                // Application level paths are always top priority.
+                array_unshift($themePaths, $directoryInfo->getRealPath());
+                $themesPathMap[$theme] = $themePaths;
+            }
         }
 
         // De-duplicate the map


### PR DESCRIPTION
This fix just ignores global themes directories at compile time if they don't exist.