### PR TITLE
Remove abstract on DebugTemplate to fix dumping logs in profiler

### DIFF
--- a/Templating/Twig/DebugTemplate.php
+++ b/Templating/Twig/DebugTemplate.php
@@ -101,6 +101,14 @@ class DebugTemplate extends Twig_Template
     /**
      * {@inheritdoc}
      */
+    public function getSource()
+    {
+        return '';
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
     protected function doDisplay(array $context, array $blocks = array())
     {
         return '';

--- a/Templating/Twig/DebugTemplate.php
+++ b/Templating/Twig/DebugTemplate.php
@@ -23,7 +23,7 @@ use Twig_Template;
  * Mainly copy/paste of eZ\Bundle\EzPublishDebugBundle\Twig\DebugTemplate, courtesy of eZ Systems AS.
  * Adds mapping between template name and path, to display actual used template source when using themes.
  */
-abstract class DebugTemplate extends Twig_Template
+class DebugTemplate extends Twig_Template
 {
     /**
      * Map between template names and associated paths.
@@ -88,5 +88,29 @@ abstract class DebugTemplate extends Twig_Template
         } else {
             echo $templateResult;
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTemplateName()
+    {
+        return '';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doDisplay(array $context, array $blocks = array())
+    {
+        return '';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDebugInfo()
+    {
+        return array();
     }
 }


### PR DESCRIPTION
Starting with https://github.com/symfony/symfony/commit/eddecbd112c13eadac6533b39287205b90430a21 and in combination with legacy eZ templates, when an exception happens (even a silenced deprecation notice, which is converted to an exception) while rendering the template, one gets a message `Cannot instantiate abstract class Lolautruche\EzCoreExtraBundle\Templating\Twig\DebugTemplate` in the log, which ultimately breaks the profiler.

The issue comes from https://github.com/symfony/symfony/blob/master/src/Symfony/Component/VarDumper/Caster/ExceptionCaster.php#L166-L167, which presumes that every subclass of `Twig_Template` is instantiable.

Haven't found other way to solve this other than this. The fix is also compatible with Twig 2.0.