### PR TITLE
Fix #22: pass parameters to ParamProvider via ezpublish.yml

### DIFF
--- a/EventListener/ViewTemplateListener.php
+++ b/EventListener/ViewTemplateListener.php
@@ -78,8 +78,8 @@ class ViewTemplateListener implements EventSubscriberInterface
                     );
                 }
 
-                $paramProviderSettings = isset($param['params']) ? (array) $param['params'] : [];
-                array_walk($paramProviderSettings, function (&$val) {
+                $paramProviderOptions = isset($param['options']) ? (array) $param['options'] : [];
+                array_walk($paramProviderOptions, function (&$val) {
                     if (!$this->settingParser->isDynamicSetting($val)) {
                         return;
                     }
@@ -96,7 +96,7 @@ class ViewTemplateListener implements EventSubscriberInterface
                         'template' => $contentView->getTemplateIdentifier(),
                         'parameters' => $contentView->getParameters(),
                     ],
-                    $paramProviderSettings
+                    $paramProviderOptions
                 );
             }
         }

--- a/EventListener/ViewTemplateListener.php
+++ b/EventListener/ViewTemplateListener.php
@@ -78,13 +78,26 @@ class ViewTemplateListener implements EventSubscriberInterface
                     );
                 }
 
+                $paramProviderSettings = isset($param['params']) ? (array) $param['params'] : [];
+                array_walk($paramProviderSettings, function (&$val) {
+                    if (!$this->settingParser->isDynamicSetting($val)) {
+                        return;
+                    }
+
+                    $parsed = $this->settingParser->parseDynamicSetting($val);
+                    $val = $this->configResolver->getParameter($parsed['param'], $parsed['namespace'], $parsed['scope']);
+                });
+
                 // Use provider to get the array of parameters and switch param value with it.
                 // The resulted array is casted to object (stdClass) for convenient use in templates.
                 // Parameter name will be unchanged. Parameters returned by provider will then be "namespaced" by the parameter name.
-                $param = (object) $this->parameterProviders[$param['provider']]->getParameters([
-                    'template' => $contentView->getTemplateIdentifier(),
-                    'parameters' => $contentView->getParameters(),
-                ]);
+                $param = (object) $this->parameterProviders[$param['provider']]->getParameters(
+                    [
+                        'template' => $contentView->getTemplateIdentifier(),
+                        'parameters' => $contentView->getParameters(),
+                    ],
+                    $paramProviderSettings
+                );
             }
         }
 

--- a/Templating/ConfigurableViewParameterProvider.php
+++ b/Templating/ConfigurableViewParameterProvider.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the EzCoreExtraBundle package.
+ *
+ * (c) Jérôme Vieilledent <jerome@vieilledent.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Lolautruche\EzCoreExtraBundle\Templating;
+
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+abstract class ConfigurableViewParameterProvider implements ViewParameterProviderInterface
+{
+    /**
+     * @var OptionsResolver
+     */
+    private $resolver;
+
+    /**
+     * Configures the OptionsResolver for the param provider.
+     *
+     * Example:
+     * ```php
+     * // type setting will be required
+     * $resolver->setRequired('type');
+     * // limit setting will be optional, and will have a default value of 10
+     * $resolver->setDefault('limit', 10);
+     * ```
+     *
+     * @param OptionsResolver $optionsResolver
+     */
+    abstract protected function configureOptions(OptionsResolver $optionsResolver);
+
+    final public function getParameters(array $viewConfig, array $settings = [])
+    {
+        return $this->doGetParameters($viewConfig, $this->getResolver()->resolve($settings));
+    }
+
+    /**
+     * Returns the hash of parameters to be injected into the matched view.
+     * Key is the parameter name, value is the parameter value.
+     *
+     * The parameters array is processed with the OptionsResolver, meaning that it has been validated, and contains
+     * the default values when applicable.
+     *
+     * @see getParameters()
+     *
+     * @param array $viewConfig Current view configuration hash.
+     *                          Available keys:
+     *                          - template: Template used for the view.
+     *                          - parameters: Hash of parameters that will be passed to the template (e.g. 'content', 'location'...)
+     * @param array $settings Configured settings for the view parameter provider.
+     *
+     * @return array
+     */
+    abstract protected function doGetParameters(array $viewConfig, array $settings = []);
+
+    /**
+     * Builds the resolver, and configures it using configureOptions().
+     *
+     * @return OptionsResolver
+     */
+    private function getResolver()
+    {
+        if ($this->resolver === null) {
+            $this->resolver = new OptionsResolver();
+            $this->configureOptions($this->resolver);
+        }
+
+        return $this->resolver;
+    }
+}

--- a/Templating/ConfigurableViewParameterProvider.php
+++ b/Templating/ConfigurableViewParameterProvider.php
@@ -35,9 +35,9 @@ abstract class ConfigurableViewParameterProvider implements ViewParameterProvide
      */
     abstract protected function configureOptions(OptionsResolver $optionsResolver);
 
-    final public function getParameters(array $viewConfig, array $settings = [])
+    final public function getParameters(array $viewConfig, array $options = [])
     {
-        return $this->doGetParameters($viewConfig, $this->getResolver()->resolve($settings));
+        return $this->doGetParameters($viewConfig, $this->getResolver()->resolve($options));
     }
 
     /**


### PR DESCRIPTION
This patch makes it possible to pass settings to view providers, easing reusability. One can for instance more easily use configurable query types.

## TODO:
- [x] Implementation
- [x] Documentation
- [x] Add more tests

Follow-up for 2.0: #32 (change `ViewParameterProviderInterface::getParameters()` signature).