### PR TITLE
Fix #32: Add new ViewParameterInterface with options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ cache:
 php:
     - 5.6
     - 7.0
+    - 7.1
+
+sudo: false
 
 branches:
     only:
@@ -14,8 +17,16 @@ branches:
         - /^\d+\.\d+$/
 
 env:
-    - EZ_KERNEL_VERSION=~2014.11
     - EZ_KERNEL_VERSION=^6.0
+
+matrix:
+    include:
+        - php: 5.6
+          env: EZ_KERNEL_VERSION=~2014.11
+        - php: 7.0
+          env: EZ_KERNEL_VERSION=^6.0
+        - php: 7.1
+          env: EZ_KERNEL_VERSION=^6.9
 
 install:
     - phpenv config-rm xdebug.ini
@@ -24,4 +35,4 @@ install:
     - composer install
 
 script:
-    - phpunit
+    - php vendor/bin/phpunit

--- a/Exception/UnsupportedException.php
+++ b/Exception/UnsupportedException.php
@@ -1,0 +1,14 @@
+<?php
+
+/*
+ * This file is part of the EzCoreExtraBundle package.
+ *
+ * @copyright Jérôme Vieilledent <jerome@vieilledent.fr>
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace Lolautruche\EzCoreExtraBundle\Exception;
+
+class UnsupportedException extends \Exception
+{
+}

--- a/Resources/doc/template_variables_injection.md
+++ b/Resources/doc/template_variables_injection.md
@@ -70,9 +70,12 @@ Services cannot be directly injected. but you can define *view parameters provid
 meaning that they will provide the variables to inject into the view template.
 Moreover, variables returned by those services will be *namespaced* by the parameter name provided in the configuration.
 
-Parameter provider services must implement `\Lolautruche\EzCoreExtraBundle\Templating\ViewParameterProviderInterface` interface
-(or extend `\Lolautruche\EzCoreExtraBundle\Templating\ConfigurableViewParameterProvider`).
+Parameter provider services must implement `\Lolautruche\EzCoreExtraBundle\View\ViewParameterProviderInterface` interface
+(or extend `\Lolautruche\EzCoreExtraBundle\View\ConfigurableViewParameterProvider`).
 Such services must be defined with `ez_core_extra.view_parameter_provider` tag.
+
+> Deprecation notice: `\Lolautruche\EzCoreExtraBundle\Templating\ViewParameterProviderInterface` has been deprecated in v1.1
+> and will be removed in v2.0.
 
 See the [full example below](#example), for details.
 
@@ -117,7 +120,8 @@ In the configuration example above, `my_param_provider` would be like:
 namespace Acme\TestBundle;
 
 use Acme\TestBundle\SomeService;
-use Lolautruche\EzCoreExtraBundle\Templating\ConfigurableViewParameterProvider;
+use Lolautruche\EzCoreExtraBundle\View\ConfigurableView;
+use Lolautruche\EzCoreExtraBundle\View\ConfigurableViewParameterProvider;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class MyViewParameterProvider extends ConfigurableViewParameterProvider
@@ -165,11 +169,11 @@ class MyViewParameterProvider extends ConfigurableViewParameterProvider
      *
      * @return array
      */
-    protected function doGetParameters(array $viewConfig, array $options = [])
+    protected function doGetParameters(ConfigurableView $view, array $options = [])
     {
         // Current location and content are available in content/location views
-        $location = $viewConfig['parameters']['location'];
-        $content = $viewConfig['parameters']['content'];
+        $location = $view->getParameter('location');
+        $content = $view->getParameter('content');
         
         // Passed options
         $contentTypeForChildren = $options['children_type'];

--- a/Templating/ViewParameterProviderInterface.php
+++ b/Templating/ViewParameterProviderInterface.php
@@ -13,6 +13,8 @@ namespace Lolautruche\EzCoreExtraBundle\Templating;
 
 /**
  * Interface for services that provides parameters to the view.
+ *
+ * @deprecated Since v1.1. Use \Lolautruche\EzCoreExtraBundle\View\ViewParameterProviderInterface instead.
  */
 interface ViewParameterProviderInterface
 {

--- a/Tests/View/ConfigurableViewTest.php
+++ b/Tests/View/ConfigurableViewTest.php
@@ -1,0 +1,202 @@
+<?php
+
+/*
+ * This file is part of the EzCoreExtraBundle package.
+ *
+ * @copyright Jérôme Vieilledent <jerome@vieilledent.fr>
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace Lolautruche\EzCoreExtraBundle\Tests\View;
+
+use Lolautruche\EzCoreExtraBundle\Exception\UnsupportedException;
+use Lolautruche\EzCoreExtraBundle\View\ConfigurableView;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
+
+class ConfigurableViewTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $innerView;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        // \eZ\Publish\Core\MVC\Symfony\View\View is only defined in kernel >=6.0
+        if (interface_exists('\eZ\Publish\Core\MVC\Symfony\View\View')) {
+            $view = $this->innerView = $this->createMock('\eZ\Publish\Core\MVC\Symfony\View\View');
+        } else {
+            $view = $this->innerView = $this->createMock('\eZ\Publish\Core\MVC\Symfony\View\ContentViewInterface');
+        }
+    }
+
+    /**
+     * @expectedException \Lolautruche\EzCoreExtraBundle\Exception\UnsupportedException
+     */
+    public function testSetTemplateIdentifier()
+    {
+        $view = new ConfigurableView($this->innerView);
+        $view->setTemplateIdentifier('foo.html.twig');
+    }
+
+    public function testGetTemplateIdentifier()
+    {
+        $this->innerView
+            ->expects($this->once())
+            ->method('getTemplateIdentifier')
+            ->willReturn('foo.html.twig');
+        $view = new ConfigurableView($this->innerView);
+        $this->assertSame('foo.html.twig', $view->getTemplateIdentifier());
+    }
+
+    public function testSetParameters()
+    {
+        $this->innerView
+            ->expects($this->once())
+            ->method('getParameters')
+            ->willReturn([]);
+        $view = new ConfigurableView($this->innerView);
+        $parameters = ['foo' => 'bar'];
+        $view->setParameters($parameters);
+        $this->assertSame($parameters, $view->getParameters());
+        $this->assertSame($parameters['foo'], $view->getParameter('foo'));
+    }
+
+    public function testAddParameters()
+    {
+        $this->innerView
+            ->expects($this->once())
+            ->method('getParameters')
+            ->willReturn(['phoenix' => 'rises']);
+        $view = new ConfigurableView($this->innerView);
+        $view->setParameters(['foo' => 'bar', 'biz' => 'buzz']);
+        $view->addParameters(['some' => 'thing', 'foo' => 'haha']);
+        $this->assertSame(
+            [
+                'foo' => 'haha',
+                'biz' => 'buzz',
+                'some' => 'thing',
+                'phoenix' => 'rises',
+            ],
+            $view->getParameters()
+        );
+    }
+
+    public function testHasParameterInnerView()
+    {
+        $this->innerView
+            ->expects($this->once())
+            ->method('hasParameter')
+            ->with('foo')
+            ->willReturn(true);
+        $view = new ConfigurableView($this->innerView);
+        $this->assertTrue($view->hasParameter('foo'));
+    }
+
+    public function testHasParameter()
+    {
+        $view = new ConfigurableView($this->innerView);
+        $this->assertFalse($view->hasParameter('foo'));
+        $view->setParameters(['foo' => 'bar']);
+        $this->assertTrue($view->hasParameter('foo'));
+    }
+
+    /**
+     * @expectedException \Lolautruche\EzCoreExtraBundle\Exception\UnsupportedException
+     */
+    public function testSetConfigHash()
+    {
+        $view = new ConfigurableView($this->innerView);
+        $view->setConfigHash([]);
+    }
+
+    public function testGetConfigHash()
+    {
+        $configHash = ['template' => 'foo.html.twig'];
+        $this->innerView
+            ->expects($this->once())
+            ->method('getConfigHash')
+            ->willReturn($configHash);
+
+        $view = new ConfigurableView($this->innerView);
+        $this->assertSame($configHash, $view->getConfigHash());
+    }
+
+    /**
+     * @expectedException \Lolautruche\EzCoreExtraBundle\Exception\UnsupportedException
+     */
+    public function testSetControllerReference()
+    {
+        $view = new ConfigurableView($this->innerView);
+        $view->setControllerReference(new ControllerReference('foo'));
+    }
+
+    public function testGetControllerReference()
+    {
+        $view = new ConfigurableView($this->innerView);
+        if (interface_exists('\eZ\Publish\Core\MVC\Symfony\View\View')) {
+            $controllerReference = new ControllerReference('foo');
+            $this->innerView
+                ->expects($this->once())
+                ->method('getControllerReference')
+                ->willReturn($controllerReference);
+            $this->assertSame($controllerReference, $view->getControllerReference());
+        } else {
+            $this->setExpectedException(UnsupportedException::class);
+            $view->getControllerReference();
+        }
+    }
+
+    /**
+     * @expectedException \Lolautruche\EzCoreExtraBundle\Exception\UnsupportedException
+     */
+    public function testSetViewType()
+    {
+        $view = new ConfigurableView($this->innerView);
+        $view->setViewType('foo');
+    }
+
+    public function testGetViewType()
+    {
+        $view = new ConfigurableView($this->innerView);
+        if (interface_exists('\eZ\Publish\Core\MVC\Symfony\View\View')) {
+            $this->innerView
+                ->expects($this->once())
+                ->method('getViewType')
+                ->willReturn('foo');
+            $this->assertSame('foo', $view->getViewType());
+        } else {
+            $this->setExpectedException(UnsupportedException::class);
+            $view->getViewType();
+        }
+    }
+
+    /**
+     * @expectedException \Lolautruche\EzCoreExtraBundle\Exception\UnsupportedException
+     */
+    public function testSetResponse()
+    {
+        $view = new ConfigurableView($this->innerView);
+        $view->setResponse(new Response());
+    }
+
+    public function testGetResponse()
+    {
+        $view = new ConfigurableView($this->innerView);
+        if (interface_exists('\eZ\Publish\Core\MVC\Symfony\View\View')) {
+            $response = new Response();
+            $this->innerView
+                ->expects($this->once())
+                ->method('getResponse')
+                ->willReturn($response);
+            $this->assertSame($response, $view->getResponse());
+        } else {
+            $this->setExpectedException(UnsupportedException::class);
+            $view->getResponse();
+        }
+    }
+}

--- a/View/ConfigurableView.php
+++ b/View/ConfigurableView.php
@@ -1,0 +1,164 @@
+<?php
+
+/*
+ * This file is part of the EzCoreExtraBundle package.
+ *
+ * @copyright Jérôme Vieilledent <jerome@vieilledent.fr>
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace Lolautruche\EzCoreExtraBundle\View;
+
+use Lolautruche\EzCoreExtraBundle\Exception\UnsupportedException;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
+
+/**
+ * Decoration of original view that can be used with view parameter providers.
+ * It is basically only possible to add new parameters and access to original view parameters.
+ */
+class ConfigurableView
+{
+    /**
+     * @var \eZ\Publish\Core\MVC\Symfony\View\View|\eZ\Publish\Core\MVC\Symfony\View\ContentViewInterface
+     */
+    private $innerView;
+
+    private $parameters = [];
+
+    public function __construct($innerView)
+    {
+        $this->innerView = $innerView;
+    }
+
+    public function setTemplateIdentifier($templateIdentifier)
+    {
+        throw new UnsupportedException(__METHOD__.' is not supported');
+    }
+
+    /**
+     * Returns the registered template identifier.
+     *
+     * @return string|\Closure
+     */
+    public function getTemplateIdentifier()
+    {
+        return $this->innerView->getTemplateIdentifier();
+    }
+
+    /**
+     * Sets $parameters that will later be injected to the template/closure.
+     * If some parameters were already present, $parameters will replace them.
+     *
+     * @param array $parameters Hash of parameters
+     */
+    public function setParameters(array $parameters)
+    {
+        $this->parameters = $parameters;
+    }
+
+    /**
+     * Adds a hash of parameters to the existing parameters.
+     *
+     * @param array $parameters
+     */
+    public function addParameters(array $parameters)
+    {
+        $this->parameters = array_replace($this->parameters, $parameters);
+    }
+
+    /**
+     * Returns registered parameters.
+     *
+     * @return array
+     */
+    public function getParameters()
+    {
+        return $this->parameters + $this->innerView->getParameters();
+    }
+
+    /**
+     * Checks if $parameterName exists.
+     *
+     * @param string $parameterName
+     *
+     * @return bool
+     */
+    public function hasParameter($parameterName)
+    {
+        return isset($this->parameters[$parameterName]) || $this->innerView->hasParameter($parameterName);
+    }
+
+    /**
+     * Returns parameter value by $parameterName.
+     *
+     * @param string $parameterName
+     *
+     * @return mixed
+     */
+    public function getParameter($parameterName)
+    {
+        if ($this->hasParameter($parameterName)) {
+            return $this->parameters[$parameterName];
+        }
+
+        return $this->innerView->getParameter($parameterName);
+    }
+
+    public function setConfigHash(array $config)
+    {
+        throw new UnsupportedException(__METHOD__.' is not supported');
+    }
+
+    /**
+     * Returns the config hash.
+     *
+     * @return array|null
+     */
+    public function getConfigHash()
+    {
+        return $this->innerView->getConfigHash();
+    }
+
+    public function setViewType($viewType)
+    {
+        throw new UnsupportedException(__METHOD__.' is not supported');
+    }
+
+    public function getViewType()
+    {
+        if (method_exists($this->innerView, 'getViewType')) {
+            return $this->innerView->getViewType();
+        }
+
+        throw new UnsupportedException(__METHOD__.' is not supported');
+    }
+
+    public function setControllerReference(ControllerReference $controllerReference)
+    {
+        throw new UnsupportedException(__METHOD__.' is not supported');
+    }
+
+    public function getControllerReference()
+    {
+        if (method_exists($this->innerView, 'getControllerReference')) {
+            return $this->innerView->getControllerReference();
+        }
+
+        throw new UnsupportedException(__METHOD__.' is not supported');
+    }
+
+    public function setResponse(Response $response)
+    {
+        throw new UnsupportedException(__METHOD__.' is not supported');
+    }
+
+    public function getResponse()
+    {
+        if (method_exists($this->innerView, 'getResponse')) {
+            return $this->innerView->getResponse();
+        }
+
+        throw new UnsupportedException(__METHOD__.' is not supported');
+    }
+}

--- a/View/ConfigurableViewParameterProvider.php
+++ b/View/ConfigurableViewParameterProvider.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Lolautruche\EzCoreExtraBundle\Templating;
+namespace Lolautruche\EzCoreExtraBundle\View;
 
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -35,9 +35,9 @@ abstract class ConfigurableViewParameterProvider implements ViewParameterProvide
      */
     abstract protected function configureOptions(OptionsResolver $optionsResolver);
 
-    final public function getParameters(array $viewConfig, array $options = [])
+    final public function getViewParameters(ConfigurableView $view, array $options = [])
     {
-        return $this->doGetParameters($viewConfig, $this->getResolver()->resolve($options));
+        return $this->doGetParameters($view, $this->getResolver()->resolve($options));
     }
 
     /**
@@ -47,17 +47,16 @@ abstract class ConfigurableViewParameterProvider implements ViewParameterProvide
      * The parameters array is processed with the OptionsResolver, meaning that it has been validated, and contains
      * the default values when applicable.
      *
+     * Available view parameters (e.g. "content", "location"...) are accessible from $view.
+     *
      * @see getParameters()
      *
-     * @param array $viewConfig Current view configuration hash.
-     *                          Available keys:
-     *                          - template: Template used for the view.
-     *                          - parameters: Hash of parameters that will be passed to the template (e.g. 'content', 'location'...)
-     * @param array $settings Configured settings for the view parameter provider.
+     * @param ConfigurableView $view Decorated matched view, containing initial parameters.
+     * @param array $options Configured settings for the view parameter provider.
      *
      * @return array
      */
-    abstract protected function doGetParameters(array $viewConfig, array $settings = []);
+    abstract protected function doGetParameters(ConfigurableView $view, array $options = []);
 
     /**
      * Builds the resolver, and configures it using configureOptions().

--- a/View/ViewParameterProviderInterface.php
+++ b/View/ViewParameterProviderInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the EzCoreExtraBundle package.
+ *
+ * @copyright Jérôme Vieilledent <jerome@vieilledent.fr>
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace Lolautruche\EzCoreExtraBundle\View;
+
+use Lolautruche\EzCoreExtraBundle\Templating\ViewParameterProviderInterface as LegacyParamProviderInterface;
+
+/**
+ * Interface for services providing parameters to a view.
+ */
+interface ViewParameterProviderInterface extends LegacyParamProviderInterface
+{
+    /**
+     * Returns a hash of parameters to inject into the matched view.
+     * Key is the parameter name, value is the parameter value.
+     *
+     * Available view parameters (e.g. "content", "location"...) are accessible from $view.
+     *
+     * @param ConfigurableView $view Decorated matched view, containing initial parameters.
+     * @param array $options
+     *
+     * @return array
+     */
+    public function getViewParameters(ConfigurableView $view, array $options = []);
+}


### PR DESCRIPTION
See #32

- Added new `Lolautruche\EzCoreExtraBundle\View\ViewParameterProviderInterface`
- Deprecated `Lolautruche\EzCoreExtraBundle\Templating\ViewParameterProviderInterface`
- Adapted `ViewTemplateListener`