### PR TITLE
Enable autoconfiguration for view parameters providers services

### DIFF
--- a/DependencyInjection/Compiler/ParameterProviderPass.php
+++ b/DependencyInjection/Compiler/ParameterProviderPass.php
@@ -30,14 +30,13 @@ class ParameterProviderPass implements CompilerPassInterface
         $viewTemplateListenerDef = $container->findDefinition('ez_core_extra.view_template_listener');
         foreach ($container->findTaggedServiceIds('ez_core_extra.view_parameter_provider') as $id => $attributes) {
             foreach ($attributes as $attribute) {
-                if (!isset($attribute['alias'])) {
-                    throw new LogicException(
-                        'ez_core_extra.view_parameter_provider service tag needs an "alias" attribute to '.
-                        'identify the parameter provider. None given.'
-                    );
-                }
-
-                $viewTemplateListenerDef->addMethodCall('addParameterProvider', [new Reference($id), $attribute['alias']]);
+                $viewTemplateListenerDef->addMethodCall(
+                    'addParameterProvider',
+                    [
+                        new Reference($id),
+                        isset($attribute['alias']) ? $attribute['alias'] : $id,
+                    ]
+                );
             }
         }
     }

--- a/DependencyInjection/EzCoreExtraExtension.php
+++ b/DependencyInjection/EzCoreExtraExtension.php
@@ -12,6 +12,7 @@
 namespace Lolautruche\EzCoreExtraBundle\DependencyInjection;
 
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ConfigurationProcessor;
+use Lolautruche\EzCoreExtraBundle\View\ViewParameterProviderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
@@ -30,6 +31,11 @@ class EzCoreExtraExtension extends Extension
         $processor = new ConfigurationProcessor($container, 'ez_core_extra');
 
         $this->configureDesigns($config, $processor, $container);
+
+        if (method_exists($container, 'registerForAutoconfiguration')) {
+            $container->registerForAutoconfiguration(ViewParameterProviderInterface::class)
+                ->addTag('ez_core_extra.view_parameter_provider');
+        }
     }
 
     private function configureDesigns(array $config, ConfigurationProcessor $processor, ContainerBuilder $container)

--- a/Resources/doc/README.md
+++ b/Resources/doc/README.md
@@ -1,0 +1,5 @@
+# EzCoreExtraBundle documentation
+
+- [Template variables injection](template_variables_injection.md)
+- [View parameters providers (dynamic variables injection)](view_parameters_providers.md)
+- [Simplified authorization checks](simplified_auth_checks.md)

--- a/Resources/doc/template_variables_injection.md
+++ b/Resources/doc/template_variables_injection.md
@@ -199,8 +199,23 @@ services:
         arguments: ["@some_service"]
         tags:
             # alias must match with value configured under "provider" key in ezplatform.yml
+            # It can be omitted, in which case it will be set as the service name (here acme_test.my_provider)
             - {name: "ez_core_extra.view_parameter_provider", alias: "my_param_provider"}
 ```
+
+> Using Symfony 3.3+, param provider services can be autoconfigured:
+
+```yaml
+services:
+    _defaults:
+        autoconfigure: true
+        
+    Acme\TestBundle\MyViewParameterProvider:
+        arguments: ['@some_service']
+```
+
+In that case, the alias will automatically be set to the service name (here the FQCN).
+
 
 #### Resulting view template
 The view template would then be like:

--- a/Resources/doc/template_variables_injection.md
+++ b/Resources/doc/template_variables_injection.md
@@ -59,23 +59,7 @@ You can inject several types of parameters:
 * Parameter references from the ServiceContainer (e.g. `%my.parameter%`)
 * [Dynamic settings](https://doc.ez.no/display/EZP/Dynamic+settings+injection) (aka *siteaccess aware parameters*,
   using `$<paramName>[;<namespace>[;<scope>]]$` syntax)
-* [Parameter provider services](#parameter-provider-services)
-
-See [full example](#full-example) for practical details.
-
-### Parameter provider services
-In some cases settings are not sufficient (i.e. if you need to always have the current ContentType available, or the current children count).
-
-Services cannot be directly injected. but you can define *view parameters provider* services,
-meaning that they will provide the variables to inject into the view template.
-Moreover, variables returned by those services will be *namespaced* by the parameter name provided in the configuration.
-
-Parameter provider services must implement `\Lolautruche\EzCoreExtraBundle\View\ViewParameterProviderInterface` interface
-(or extend `\Lolautruche\EzCoreExtraBundle\View\ConfigurableViewParameterProvider`).
-Such services must be defined with `ez_core_extra.view_parameter_provider` tag.
-
-See the [full example below](#example), for details.
-
+* [Parameters provider services](view_parameter_providers.md) (for more dynamic injection using custom services)
 
 ### Example
 This feature would allow to configure a content/location/block view the following way:
@@ -90,12 +74,6 @@ ezpublish:
                     article_test:
                         template: "AcmeTestBundle:full:article_test.html.twig"
                         params:
-                            # This service must implement \Lolautruche\EzCoreExtraBundle\Templating\ViewParameterProviderInterface.
-                            # It's possible to pass options as a hash under the "options" key.
-                            # This hash will be passed as 2nd argument to your service's "getParameters()" method.
-                            my_provider: 
-                                provider: "my_param_provider", 
-                                options: { children_type: "article", children_limit: 10 }
                             osTypes: [osx, linux, losedows]
                             secret: "%secret%"
                             # Parameters resolved by config resolver
@@ -109,134 +87,25 @@ ezpublish:
 
 > **Important**: Note that all configured parameters are only available in the template spotted in the template selection rule.
 
-#### Parameter provider example
-In the configuration example above, `my_param_provider` would be like:
-
-```php
-<?php
-namespace Acme\TestBundle;
-
-use Acme\TestBundle\SomeService;
-use Lolautruche\EzCoreExtraBundle\View\ConfigurableView;
-use Lolautruche\EzCoreExtraBundle\View\ConfigurableViewParameterProvider;
-use Symfony\Component\OptionsResolver\OptionsResolver;
-
-class MyViewParameterProvider extends ConfigurableViewParameterProvider
-{
-    private $someService;
-
-    /**
-     * Injected service is just an example. It can be whatever dependency you need
-     */
-    public function __construct(SomeService $someService)
-    {
-        $this->someService = $someService;
-    }
-    
-    /**
-     * Configures the OptionsResolver for the param provider.
-     * If you don't use options, just leave the method body empty.
-     *
-     * Example:
-     * ```php
-     * // type setting will be required
-     * $resolver->setRequired('type');
-     * // limit setting will be optional, and will have a default value of 10
-     * $resolver->setDefault('limit', 10);
-     * ```
-     *
-     * @param OptionsResolver $optionsResolver
-     */
-    protected function configureOptions(OptionsResolver $optionsResolver)
-    {
-        $optionsResolver
-            ->setRequired(['children_type', 'limit'])
-            ->setAllowedTypes('limit', ['int']);
-    }
-
-    /**
-     * Returns a hash of parameters to inject into the matched view.
-     * Key is the parameter name, value is the parameter value.
-     *
-     * @param array $viewConfig Current view configuration hash.
-     *                          Available keys:
-     *                              - template: Template used for the view.
-     *                              - parameters: Hash of parameters that will be passed to the template.
-     * @param array $options Options hash for the param provider, in current context.
-     *
-     * @return array
-     */
-    protected function doGetParameters(ConfigurableView $view, array $options = [])
-    {
-        // Current location and content are available in content/location views
-        $location = $view->getLocation();
-        $content = $view->getContent();
-        
-        // Passed options
-        $contentTypeForChildren = $options['children_type'];
-        $childrenLimit = $options['children_limit'];
-        // Fetch children with those options
-        // $fetchedChildren = ...
-
-        return array(
-            'foo' => $this->someService->giveMeFoo(),
-            'some' => 'thing',
-            'children' => $fetchedChildren,
-        );
-    }
-}
-```
-
-> For convenience, `ConfigurableViewParameterProvider` abstract class is provided.
-> It may help to validate supported options thanks to the `OptionsResolver` component.
-
-Now defining the service:
-
-```yaml
-services:
-    acme_test.my_provider:
-        class: Acme\TestBundle\MyViewParameterProvider
-        arguments: ["@some_service"]
-        tags:
-            # alias must match with value configured under "provider" key in ezplatform.yml
-            # It can be omitted, in which case it will be set as the service name (here acme_test.my_provider)
-            - {name: "ez_core_extra.view_parameter_provider", alias: "my_param_provider"}
-```
-
-> Using Symfony 3.3+, param provider services can be autoconfigured:
-
-```yaml
-services:
-    _defaults:
-        autoconfigure: true
-        
-    Acme\TestBundle\MyViewParameterProvider:
-        arguments: ['@some_service']
-```
-
-In that case, the alias will automatically be set to the service name (here the FQCN).
-
+> For more advanced and dynamic injection, you may implement a **[ViewParametersProvider service](view_parameters_providers.md)**.
 
 #### Resulting view template
 The view template would then be like:
 
 ```jinja
-{% extends "AcmeDemoBundle::pagelayout.html.twig" %}
+{% extends "pagelayout.html.twig" %}
 
 {% block content %}
-<h1>{{ ez_render_field(content, 'title') }}</h1>
+    <h1>{{ ez_render_field(content, 'title') }}</h1>
+    
+    <p><strong>Secret:</strong> {{ secret }}</p>
+    
+    <p><strong>OS Types:</strong></p>
+    {% for os in osTypes %}
+        {{ os }}
+        {% if not loop.last %}, {% endif %}
+    {% endfor %}
 
-<p><strong>Secret:</strong> {{ secret }}</p>
-
-<p><strong>OS Types:</strong></p>
-{% for os in osTypes %}
-    {{ os }}
-    {% if not loop.last %}, {% endif %}
-{% endfor %}
-
-{# Param provider is namespaced by "my_provider" according to configuration #}
-<p>{{ my_provider.foo }}</p>
-<p>{{ my_provider.some }}</p>
 {% endblock %}
 
 ```

--- a/Resources/doc/view_parameters_providers.md
+++ b/Resources/doc/view_parameters_providers.md
@@ -1,0 +1,156 @@
+# View parameters providers
+
+For template variables injection, simple settings may not be sufficient 
+(i.e. if you need to always have the current ContentType available, or the current children count).
+
+By design, **services cannot be directly injected**. but you can define *view parameters provider* services,
+which **goal is to provide variables to inject into view templates**.
+Moreover, variables returned by those services will be *namespaced* by the parameter name provided in the configuration.
+
+Parameters provider services must implement `Lolautruche\EzCoreExtraBundle\View\ViewParameterProviderInterface` interface
+(or extend `Lolautruche\EzCoreExtraBundle\View\ConfigurableViewParameterProvider`).
+Such services must be defined with `ez_core_extra.view_parameter_provider` tag.
+
+A Parameters provider may expose options that one can set in the view configuration to alter the service behavior.
+
+## Parameters provider example
+
+In the following example we define a `MetaDataProvider` that provides the `ContentType` of each viewed content.
+It also provides the content author. By default it will load the content owner name, with the possibility to use an
+author field (see exposed options).
+
+```php
+<?php
+
+namespace AppBundle\Provider;
+
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\UserService;
+use Lolautruche\EzCoreExtraBundle\View\ConfigurableView;
+use Lolautruche\EzCoreExtraBundle\View\ConfigurableViewParameterProvider;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class MetaDataProvider extends ConfigurableViewParameterProvider
+{
+    /**
+     * @var UserService
+     */
+    private $userService;
+
+    /**
+     * @var ContentTypeService
+     */
+    private $contentTypeService;
+
+    public function __construct(UserService $userService, ContentTypeService $contentTypeService)
+    {
+        $this->userService = $userService;
+        $this->contentTypeService = $contentTypeService;
+    }
+
+    /**
+     * Returns a hash of parameters to inject into the matched view.
+     * Key is the parameter name, value is the parameter value.
+     *
+     * Available view parameters (e.g. "content", "location"...) are accessible from $view.
+     *
+     * @param ConfigurableView $view Decorated matched view, containing initial parameters.
+     * @param array $options
+     *
+     * @return array
+     */
+    public function doGetParameters(ConfigurableView $view, array $options = [])
+    {
+        $content = $view->getContent();
+
+        if ($options['use_author_field']) {
+            $authorName = (string)$content->getFieldValue($options['author_field_name']);
+        }
+
+        return [
+            'author' => $authorName ?? $this->userService->loadUser($content->contentInfo->ownerId)->getName(),
+            'contentType' => $this->contentTypeService->loadContentType($content->contentInfo->contentTypeId),
+        ];
+    }
+
+    /**
+     * Configures the OptionsResolver for the param provider.
+     *
+     * Example:
+     * ```php
+     * // type setting will be required
+     * $resolver->setRequired('type');
+     * // limit setting will be optional, and will have a default value of 10
+     * $resolver->setDefault('limit', 10);
+     * ```
+     *
+     * @param OptionsResolver $optionsResolver
+     */
+    protected function configureOptions(OptionsResolver $optionsResolver)
+    {
+        $optionsResolver
+            ->setDefaults([
+                'use_author_field' => false,
+                'author_field_name' => 'author',
+            ]);
+    }
+}
+```
+
+### Service configuration
+```yaml
+services:
+    app.metadata_provider:
+        class: AppBundle\Provider\MetaDataProvider
+        arguments: ['@ezpublish.api.service.user', '@ezpublish.api.service.content_type']
+        tags:
+            # By default the provider alias will be the service name, but you may customize it using "alias" tag attribute.
+            - { name: ez_core_extra.view_parameter_provider }
+```
+
+Using Symfony 3.3+ it can be simplified thanks to autoconfiguration:
+
+```yaml
+services:
+    _defaults:
+        autoconfigure: true
+        
+    AppBundle\Provider\MetaDataProvider:
+        arguments: ['@ezpublish.api.service.user', '@ezpublish.api.service.content_type']
+```
+
+### View configuration
+```yaml
+ezpublish:
+    system:
+        my_siteaccess:
+            location_view:
+                full:
+                    article_test:
+                        template: "@ezdesign/full/article_test.html.twig"
+                        params:
+                            # Key is the name of the variable "namespace" in the template (see template below)
+                            metadata: 
+                                # provider key corresponds to the provider service name (or alias if defined).
+                                # When using FQCN as service name with Symfony 3.3+, just set the FQCN as value:
+                                # provider: "AppBundle\Provider\MetaDataProvider"
+                                provider: "app.metadata_provider", 
+                                options: 
+                                    use_author_field: true
+                                    author_field_name: author
+                        match:
+                            Id\Location: 144
+```
+
+### Resulting view
+```jinja
+{% extends "pagelayout.html.twig" %}
+
+{% block content %}
+<h1>{{ ez_render_field(content, 'title') }}</h1>
+
+{# Param provider is namespaced by "metadata" according to configuration #}
+<p>Author: {{ metadata.author }}</p>
+<p>ContentType name: {{ metadata.contentType.name }}</p>
+{% endblock %}
+```


### PR DESCRIPTION
Fixes #36 

Also improved documentation a bit.

Now a param provider can be defined the following way:

```yaml
services:
    _defaults:
        autoconfigure: true

    AppBundle\My\Provider:
        arguments: ['@my_service']
```

In that case the provider *alias* will be the service name: `AppBundle\My\Provider`.