### PR TITLE
Fix #37: Add expression support in configured view parameters

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -3,7 +3,12 @@ parameters:
 services:
     ez_core_extra.view_template_listener:
         class: Lolautruche\EzCoreExtraBundle\EventListener\ViewTemplateListener
-        arguments: ["@ezpublish.config.resolver", "@ezpublish.config.dynamic_setting.parser"]
+        arguments:
+            - "@ezpublish.config.resolver"
+            - "@ezpublish.config.dynamic_setting.parser"
+            - "@ezpublish.api.repository"
+            - "@ez_core_extra.view.expression_language"
+
         tags:
             - { name: kernel.event_subscriber }
 
@@ -23,3 +28,6 @@ services:
             - "@ezpublish.security.voter.value_object"
         tags:
             - { name: "security.voter" }
+
+    ez_core_extra.view.expression_language:
+        class: Lolautruche\EzCoreExtraBundle\View\ExpressionLanguage

--- a/Resources/doc/README.md
+++ b/Resources/doc/README.md
@@ -1,5 +1,6 @@
 # EzCoreExtraBundle documentation
 
 - [Template variables injection](template_variables_injection.md)
+- [Template variables injection using **ExpressionLanguage**](view_parameters_expressions.md)
 - [View parameters providers (dynamic variables injection)](view_parameters_providers.md)
 - [Simplified authorization checks](simplified_auth_checks.md)

--- a/Resources/doc/template_variables_injection.md
+++ b/Resources/doc/template_variables_injection.md
@@ -59,7 +59,8 @@ You can inject several types of parameters:
 * Parameter references from the ServiceContainer (e.g. `%my.parameter%`)
 * [Dynamic settings](https://doc.ez.no/display/EZP/Dynamic+settings+injection) (aka *siteaccess aware parameters*,
   using `$<paramName>[;<namespace>[;<scope>]]$` syntax)
-* [Parameters provider services](view_parameter_providers.md) (for more dynamic injection using custom services)
+* [Expressions](view_parameters_expressions.md) (for dynamic injection with ExpressionLanguage)
+* [Parameters provider services](view_parameter_providers.md) (for more dynamic injection using custom reusable services)
 
 ### Example
 This feature would allow to configure a content/location/block view the following way:
@@ -72,7 +73,7 @@ ezpublish:
             location_view:
                 full:
                     article_test:
-                        template: "AcmeTestBundle:full:article_test.html.twig"
+                        template: "@ezdesign/full/article_test.html.twig"
                         params:
                             osTypes: [osx, linux, losedows]
                             secret: "%secret%"
@@ -87,7 +88,8 @@ ezpublish:
 
 > **Important**: Note that all configured parameters are only available in the template spotted in the template selection rule.
 
-> For more advanced and dynamic injection, you may implement a **[ViewParametersProvider service](view_parameters_providers.md)**.
+> For more advanced and dynamic injection, you may use **[Expressions](view_parameters_expressions.md)**
+> or implement a **[ViewParametersProvider service](view_parameters_providers.md)**.
 
 #### Resulting view template
 The view template would then be like:

--- a/Resources/doc/view_parameters_expressions.md
+++ b/Resources/doc/view_parameters_expressions.md
@@ -1,0 +1,51 @@
+# View parameters expressions
+
+Instead of injecting plain parameters, or dynamic settings into view variables, it is possible to use expressions
+that will be evaluated in context before being injected.
+
+This feature is written on top of [Symfony ExpressionLanguage component](https://symfony.com/doc/current/components/expression_language.html).
+
+## Example
+
+```yaml
+# ezplatform.yml
+ezpublish:
+    system:
+        my_siteaccess:
+            location_view:
+                full:
+                    article_test:
+                        template: "@ezdesign/full/article_test.html.twig"
+                        params:
+                            parentLocation:
+                                expression: "loadLocation(location.parentLocationId)"
+                            metadata:
+                                expression: "{
+                                    'contentTypeIdentifier': contentType.identifier,
+                                    'section': repository.getSectionService().loadSection(content.contentInfo.sectionId),
+                                    'owner': repository.getUserService().loadUser(content.contentInfo.ownerId),
+                                    'secret': '%secret%'
+                                }"
+                        match:
+                            Id\Location: 144
+```
+
+## Exposed variables and functions
+In order to build your expressions, several variables and functions are exposed
+
+### Variables
+| Variable name    | Type                                                        | Description                           |
+|------------------|-------------------------------------------------------------|---------------------------------------|
+| `view`           | `Lolautruche\EzCoreExtraBundle\View\ConfigurableView`       | The **content view** being configured |
+| `content`        | `eZ\Publish\Core\Repository\Values\Content\Content`         | Current content                       |
+| `location`       | `eZ\Publish\Core\Repository\Values\Content\Location`        | Current location                      |
+| `contentType`    | `eZ\Publish\Core\Repository\Values\ContentType\ContentType` | ContentType of the current content    |
+| `configResolver` | `eZ\Publish\Core\MVC\ConfigResolverInterface`               | The ConfigResolver                    |
+| `repository`     | `eZ\Publish\Core\Repository\Repository`                     | The content repository                |
+
+### Functions
+| Function name     | Description                      |
+|-------------------|----------------------------------|
+| `loadLocation`    | Loads a location object by ID    |
+| `loadContent`     | Loads a content object by ID     |
+| `loadContentType` | Loads a contentType object by ID |

--- a/Resources/doc/view_parameters_providers.md
+++ b/Resources/doc/view_parameters_providers.md
@@ -13,6 +13,8 @@ Such services must be defined with `ez_core_extra.view_parameter_provider` tag.
 
 A Parameters provider may expose options that one can set in the view configuration to alter the service behavior.
 
+Cherry on the cake, such services are reusable across all the content views in your eZ application. 
+
 ## Parameters provider example
 
 In the following example we define a `MetaDataProvider` that provides the `ContentType` of each viewed content.

--- a/View/ExpressionLanguage.php
+++ b/View/ExpressionLanguage.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the EzCoreExtraBundle package.
+ *
+ * @copyright Jérôme Vieilledent <jerome@vieilledent.fr>
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace Lolautruche\EzCoreExtraBundle\View;
+
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage as BaseExpressionLanguage;
+
+class ExpressionLanguage extends BaseExpressionLanguage
+{
+    public function __construct($cache = null, array $providers = array())
+    {
+        // prepend the default provider to let users override it easily
+        array_unshift($providers, new ExpressionLanguageProvider());
+
+        parent::__construct($cache, $providers);
+    }
+}

--- a/View/ExpressionLanguageProvider.php
+++ b/View/ExpressionLanguageProvider.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the EzCoreExtraBundle package.
+ *
+ * @copyright Jérôme Vieilledent <jerome@vieilledent.fr>
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace Lolautruche\EzCoreExtraBundle\View;
+
+use Symfony\Component\ExpressionLanguage\ExpressionFunction;
+use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
+
+class ExpressionLanguageProvider implements ExpressionFunctionProviderInterface
+{
+    /**
+     * @return ExpressionFunction[]
+     */
+    public function getFunctions()
+    {
+        return [
+            new ExpressionFunction('loadLocation', function ($arg) {
+                return sprintf('$repository->getLocationService()->loadLocation(%s)', $arg);
+            }, function (array $variables, $value) {
+                return $variables['repository']->getLocationService()->loadLocation($value);
+            }),
+
+            new ExpressionFunction('loadContent', function ($arg) {
+                return sprintf('$repository->getContentService()->loadContent(%s)', $arg);
+            }, function (array $variables, $value) {
+                return $variables['repository']->getContentService()->loadContent($value);
+            }),
+
+            new ExpressionFunction('loadContentType', function ($arg) {
+                return sprintf('$repository->getContentTypeService()->loadContentType(%s)', $arg);
+            }, function (array $variables, $value) {
+                return $variables['repository']->getContentTypeService()->loadContentType($value);
+            }),
+        ];
+    }
+}


### PR DESCRIPTION
This implements support for Expressions for variables injection into content views.

## Example

```yaml
# ezplatform.yml
ezpublish:
    system:
        my_siteaccess:
            location_view:
                full:
                    article_test:
                        template: "@ezdesign/full/article_test.html.twig"
                        params:
                            parentLocation:
                                expression: "loadLocation(location.parentLocationId)"
                            metadata:
                                expression: "{
                                    'contentTypeIdentifier': contentType.identifier,
                                    'section': repository.getSectionService().loadSection(content.contentInfo.sectionId),
                                    'owner': repository.getUserService().loadUser(content.contentInfo.ownerId),
                                    'secret': '%secret%'
                                }"
                        match:
                            Id\Location: 144
```

## Exposed variables and functions
In order to build your expressions, several variables and functions are exposed

### Variables
| Variable name    | Type                                                        | Description                           |
|------------------|-------------------------------------------------------------|---------------------------------------|
| `view`           | `Lolautruche\EzCoreExtraBundle\View\ConfigurableView`       | The **content view** being configured |
| `content`        | `eZ\Publish\Core\Repository\Values\Content\Content`         | Current content                       |
| `location`       | `eZ\Publish\Core\Repository\Values\Content\Location`        | Current location                      |
| `contentType`    | `eZ\Publish\Core\Repository\Values\ContentType\ContentType` | ContentType of the current content    |
| `configResolver` | `eZ\Publish\Core\MVC\ConfigResolverInterface`               | The ConfigResolver                    |
| `repository`     | `eZ\Publish\Core\Repository\Repository`                     | The content repository                |

### Functions
| Function name     | Description                      |
|-------------------|----------------------------------|
| `loadLocation`    | Loads a location object by ID    |
| `loadContent`     | Loads a content object by ID     |
| `loadContentType` | Loads a contentType object by ID |