### PR TITLE
Implemented user authentication by email

### DIFF
--- a/DependencyInjection/Compiler/SecurityPass.php
+++ b/DependencyInjection/Compiler/SecurityPass.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the EzCoreExtraBundle package.
+ *
+ * @copyright Jérôme Vieilledent <jerome@vieilledent.fr>
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace Lolautruche\EzCoreExtraBundle\DependencyInjection\Compiler;
+
+use Lolautruche\EzCoreExtraBundle\Security\RepositoryAuthenticationProvider;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class SecurityPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('security.authentication.provider.dao')) {
+            return;
+        }
+
+        $container->findDefinition('security.authentication.provider.dao')
+            ->setClass(RepositoryAuthenticationProvider::class)
+            ->addMethodCall('setConfigResolver', [new Reference('ezpublish.config.resolver')]);
+    }
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -29,6 +29,10 @@ class Configuration extends SiteAccessConfiguration
                 ->useAttributeAsKey('variable_name')
                 ->example(array('foo' => '"bar"', 'pi' => 3.14))
                 ->prototype('variable')->end()
+            ->end()
+            ->booleanNode('enable_email_authentication')
+                ->info('Whether eZ users can authenticate against their e-mail or not.')
+                ->defaultTrue()
             ->end();
 
         return $treeBuilder;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -32,7 +32,7 @@ class Configuration extends SiteAccessConfiguration
             ->end()
             ->booleanNode('enable_email_authentication')
                 ->info('Whether eZ users can authenticate against their e-mail or not.')
-                ->defaultTrue()
+                ->defaultFalse()
             ->end();
 
         return $treeBuilder;

--- a/DependencyInjection/EzCoreExtraExtension.php
+++ b/DependencyInjection/EzCoreExtraExtension.php
@@ -12,6 +12,7 @@
 namespace Lolautruche\EzCoreExtraBundle\DependencyInjection;
 
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ConfigurationProcessor;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface;
 use Lolautruche\EzCoreExtraBundle\View\ViewParameterProviderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
@@ -31,6 +32,12 @@ class EzCoreExtraExtension extends Extension
         $processor = new ConfigurationProcessor($container, 'ez_core_extra');
 
         $this->configureDesigns($config, $processor, $container);
+        $processor->mapConfig(
+            $config,
+            function (array $scopeSettings, $currentScope, ContextualizerInterface $contextualizer) {
+                $contextualizer->setContextualParameter('security.authentication_email.enabled', $currentScope, $scopeSettings['enable_email_authentication']);
+            }
+        );
 
         if (method_exists($container, 'registerForAutoconfiguration')) {
             $container->registerForAutoconfiguration(ViewParameterProviderInterface::class)

--- a/EzCoreExtraBundle.php
+++ b/EzCoreExtraBundle.php
@@ -12,6 +12,7 @@
 namespace Lolautruche\EzCoreExtraBundle;
 
 use Lolautruche\EzCoreExtraBundle\DependencyInjection\Compiler\ParameterProviderPass;
+use Lolautruche\EzCoreExtraBundle\DependencyInjection\Compiler\SecurityPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -21,5 +22,6 @@ class EzCoreExtraBundle extends Bundle
     {
         parent::build($container);
         $container->addCompilerPass(new ParameterProviderPass());
+        $container->addCompilerPass(new SecurityPass());
     }
 }

--- a/README.md
+++ b/README.md
@@ -55,10 +55,23 @@ Adds extra features to eZ Platform.
 
   Simplifies calls to `$this->isGranted()` from inside controllers and `is_granted()` from within templates when checking
   against eZ inner permission system (module/function/valueObject).
+  
+* **[Authentication by e-mail](Resources/doc/email_authentication.md)**
+
+  By activating `enable_email_authentication` flag, it will be possible for users to authenticate using their e-mail,
+  in addition to their username.
+  
+  ```yaml
+  ez_core_extra:
+      system:
+          my_siteaccess:
+              enable_email_authentication: true
+  ``` 
 
 ## Requirements
-EzCoreExtraBundle currently works with **eZ Publish 5.4/2014.11** (and *should work* with Netgen variant)
-and eZ Platform (kernel version >=6.0).
+EzCoreExtraBundle currently works eZ Platform v1 and v2 (kernel v6 and v7).
+
+> If you're using eZ publish 5.4/2014.11 or Netgen variant, look at `1.1` branch and/or `v1.x` releases.
 
 ## Installation
 This bundle is available on [Packagist](https://packagist.org/packages/lolautruche/ez-core-extra-bundle).
@@ -69,6 +82,8 @@ composer require lolautruche/ez-core-extra-bundle
 ```
 
 Then add it to your application:
+
+> `EzCoreExtraBundle` **MUST** be instanciated **AFTER** eZ bundles.
 
 ```php
 // ezpublish/EzPublishKernel.php

--- a/Resources/config/default_settings.yml
+++ b/Resources/config/default_settings.yml
@@ -1,3 +1,3 @@
 parameters:
     ez_core_extra.default.twig_globals: {}
-    ez_core_extra.default.security.authentication_email.enabled: true
+    ez_core_extra.default.security.authentication_email.enabled: false

--- a/Resources/config/default_settings.yml
+++ b/Resources/config/default_settings.yml
@@ -1,2 +1,3 @@
 parameters:
     ez_core_extra.default.twig_globals: {}
+    ez_core_extra.default.security.authentication_email.enabled: true

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -31,3 +31,12 @@ services:
 
     ez_core_extra.view.expression_language:
         class: Lolautruche\EzCoreExtraBundle\View\ExpressionLanguage
+
+    ez_core_extra.security.email_user_provider:
+        class: Lolautruche\EzCoreExtraBundle\Security\UserProvider
+        decorates: ezpublish.security.user_provider
+        arguments:
+            - '@ez_core_extra.security.email_user_provider.inner'
+            - '@ezpublish.api.service.user'
+        calls:
+            - ['setConfigResolver', ['@ezpublish.config.resolver']]

--- a/Resources/doc/README.md
+++ b/Resources/doc/README.md
@@ -4,3 +4,4 @@
 - [Template variables injection using **ExpressionLanguage**](view_parameters_expressions.md)
 - [View parameters providers (dynamic variables injection)](view_parameters_providers.md)
 - [Simplified authorization checks](simplified_auth_checks.md)
+- [Authentication by e-mail](email_authentication.md)

--- a/Resources/doc/email_authentication.md
+++ b/Resources/doc/email_authentication.md
@@ -1,0 +1,22 @@
+# Authentication by e-mail
+
+By default, eZ users can only authenticate using their username. However, using e-mail for authentication is quite a
+common use case.
+
+EzCoreExtraBundle enables the possibility for any eZ user to authenticate against their e-mail, in addition to their username.
+
+You can easily activate it for your SiteAccess using the following config, where `my_siteaccess` is the name of
+your SiteAccess or SiteAccess group:
+
+```yaml
+ez_core_extra:
+    system:
+        my_siteaccess:
+            enable_email_authentication: true
+```
+
+Original behavior - authentication by username - is kept and will always have precedence (e.g. username will always
+be tested first).
+
+> **Important note**: `EzCoreExtraBundle` **MUST** be instanciated 
+> **after eZ bundles** in `AppKernel`.

--- a/Security/EmailAuthenticationActivationChecker.php
+++ b/Security/EmailAuthenticationActivationChecker.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the EzCoreExtraBundle package.
+ *
+ * @copyright Jérôme Vieilledent <jerome@vieilledent.fr>
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace Lolautruche\EzCoreExtraBundle\Security;
+
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+
+trait EmailAuthenticationActivationChecker
+{
+    /**
+     * @var ConfigResolverInterface
+     */
+    private $configResolver;
+
+    public function setConfigResolver(ConfigResolverInterface $configResolver)
+    {
+        $this->configResolver = $configResolver;
+    }
+
+    /**
+     * @return bool
+     */
+    protected function isEmailAuthenticationEnabled()
+    {
+        return (bool)$this->configResolver->getParameter('security.authentication_email.enabled', 'ez_core_extra');
+    }
+}

--- a/Security/RepositoryAuthenticationProvider.php
+++ b/Security/RepositoryAuthenticationProvider.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the EzCoreExtraBundle package.
+ *
+ * @copyright Jérôme Vieilledent <jerome@vieilledent.fr>
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace Lolautruche\EzCoreExtraBundle\Security;
+
+use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\Core\MVC\Symfony\Security\Authentication\RepositoryAuthenticationProvider as BaseProvider;
+use eZ\Publish\Core\MVC\Symfony\Security\UserInterface as EzUserInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Exception\BadCredentialsException;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * eZ Repository authentication provider override.
+ * Allows to authenticate against e-mail, in addition to traditional username.
+ *
+ * Original behavior is kept and always has precedence.
+ */
+class RepositoryAuthenticationProvider extends BaseProvider
+{
+    use EmailAuthenticationActivationChecker;
+
+    /**
+     * @var Repository
+     */
+    private $contentRepository;
+
+    /**
+     * @var \eZ\Publish\API\Repository\UserService
+     */
+    private $userService;
+
+    public function setRepository(Repository $repository)
+    {
+        parent::setRepository($repository);
+        $this->contentRepository = $repository;
+        $this->userService = $repository->getUserService();
+    }
+
+    protected function checkAuthentication(UserInterface $user, UsernamePasswordToken $token)
+    {
+        try {
+            parent::checkAuthentication($user, $token);
+        } catch (BadCredentialsException $e) {
+            if (!($this->isEmailAuthenticationEnabled() && $user instanceof EzUserInterface)) {
+                throw $e;
+            }
+
+            // This check was already made in parent implementation and really represents an exception, so rethrow it.
+            if ($token->getUser() instanceof UserInterface) {
+                throw $e;
+            }
+
+            try {
+                $authenticatedRepoUser = $this->userService->loadUserByCredentials($user->getUsername(), $token->getCredentials());
+                $this->contentRepository->setCurrentUser($authenticatedRepoUser);
+            } catch (NotFoundException $exception) {
+                throw new BadCredentialsException('Invalid credentials', 0, $e);
+            }
+        }
+    }
+}

--- a/Security/UserProvider.php
+++ b/Security/UserProvider.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the EzCoreExtraBundle package.
+ *
+ * (c) Jérôme Vieilledent <jerome@vieilledent.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Lolautruche\EzCoreExtraBundle\Security;
+
+use eZ\Publish\API\Repository\UserService;
+use eZ\Publish\API\Repository\Values\User\User as APIUser;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use eZ\Publish\Core\MVC\Symfony\Security\User\APIUserProviderInterface;
+use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
+use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * eZ User provider decorator.
+ * Allows to fetch users using e-mail, in addition to traditional username.
+ */
+class UserProvider implements APIUserProviderInterface
+{
+    use EmailAuthenticationActivationChecker;
+
+    /**
+     * @var APIUserProviderInterface
+     */
+    private $innerUserProvider;
+
+    /**
+     * @var UserService
+     */
+    private $userService;
+
+    public function __construct(APIUserProviderInterface $innerUserProvider, UserService $userService)
+    {
+        $this->innerUserProvider = $innerUserProvider;
+        $this->userService = $userService;
+    }
+
+    public function loadUserByUsername($username)
+    {
+        try {
+            return $this->innerUserProvider->loadUserByUsername($username);
+        } catch (UsernameNotFoundException $e) {
+            if (!$this->isEmailAuthenticationEnabled()) {
+                throw $e;
+            }
+
+            $users = $this->userService->loadUsersByEmail($username);
+            if (empty($users)) {
+                throw new UsernameNotFoundException("Could not find a user with idenfifier $username");
+            }
+
+            return $this->loadUserByAPIUser(reset($users));
+        }
+    }
+
+    public function refreshUser(UserInterface $user)
+    {
+        return $this->innerUserProvider->refreshUser($user);
+    }
+
+    public function supportsClass($class)
+    {
+        return $this->innerUserProvider->supportsClass($class);
+    }
+
+    public function loadUserByAPIUser(APIUser $apiUser)
+    {
+        return $this->innerUserProvider->loadUserByAPIUser($apiUser);
+    }
+}

--- a/Tests/Security/RepositoryAuthenticationProviderTest.php
+++ b/Tests/Security/RepositoryAuthenticationProviderTest.php
@@ -1,0 +1,203 @@
+<?php
+/*
+ * This file is part of the EzCoreExtraBundle package.
+ *
+ * @copyright Jérôme Vieilledent <jerome@vieilledent.fr>
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace Lolautruche\EzCoreExtraBundle\Tests\Security;
+
+use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\API\Repository\UserService;
+use eZ\Publish\Core\Base\Exceptions\NotFoundException;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use eZ\Publish\Core\Repository\Values\User\User as APIUser;
+use Lolautruche\EzCoreExtraBundle\Security\RepositoryAuthenticationProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
+use Symfony\Component\Security\Core\Exception\BadCredentialsException;
+use Symfony\Component\Security\Core\User\UserCheckerInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+use eZ\Publish\Core\MVC\Symfony\Security\User;
+
+class RepositoryAuthenticationProviderTest extends TestCase
+{
+    /**
+     * @var MockObject|Repository
+     */
+    private $repository;
+
+    /**
+     * @var MockObject|UserService
+     */
+    private $userService;
+
+    /**
+     * @var MockObject|ConfigResolverInterface
+     */
+    private $configResolver;
+
+    /**
+     * @var RepositoryAuthenticationProvider
+     */
+    private $authProvider;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->userService = $this->createMock(UserService::class);
+        $this->repository = $this->createMock(Repository::class);
+        $this->repository
+            ->method('getUserService')
+            ->willReturn($this->userService);
+        $this->configResolver = $this->createMock(ConfigResolverInterface::class);
+
+        $this->authProvider = new RepositoryAuthenticationProvider(
+            $this->createMock(UserProviderInterface::class),
+            $this->createMock(UserCheckerInterface::class),
+            'ezpublish_front',
+            $this->createMock(EncoderFactoryInterface::class)
+        );
+        $this->authProvider->setRepository($this->repository);
+        $this->authProvider->setConfigResolver($this->configResolver);
+    }
+
+    public function testCheckAuthenticationUsername()
+    {
+        $user = $this->createMock(User::class);
+        $userName = 'my_username';
+        $password = 'foo';
+        $token = new UsernamePasswordToken($userName, $password, 'bar');
+
+        $apiUser = $this->createMock(APIUser::class);
+        $this->userService
+            ->expects($this->once())
+            ->method('loadUserByCredentials')
+            ->with($userName, $password)
+            ->willReturn($apiUser);
+        $this->repository
+            ->expects($this->once())
+            ->method('setCurrentUser')
+            ->with($apiUser);
+
+        $method = new \ReflectionMethod($this->authProvider, 'checkAuthentication');
+        $method->setAccessible(true);
+        $method->invoke($this->authProvider, $user, $token);
+    }
+
+    public function testCheckAuthenticationEmail()
+    {
+        $username = 'lolautruche';
+        $userEmail = 'jerome@code-rhapsodie.fr';
+        $password = 'foo';
+        $user = $this->createMock(User::class);
+        $user
+            ->method('getUsername')
+            ->willReturn($username);
+        $token = new UsernamePasswordToken($userEmail, $password, 'bar');
+
+        $this->configResolver
+            ->method('getParameter')
+            ->with('security.authentication_email.enabled', 'ez_core_extra')
+            ->willReturn(true);
+
+        $apiUser = new APIUser(['login' => $username, 'email' => $userEmail]);
+        // First call to UserService::loadUserByCredentials is done by original RepositoryAuthenticationProvider.
+        // It's supposed to fail since it's an email, and thus to thrown a BadCredentialsException.
+        $this->userService
+            ->expects($this->at(0))
+            ->method('loadUserByCredentials')
+            ->with($userEmail, $password)
+            ->willThrowException(new BadCredentialsException());
+        // 2nd call is done by our authentication provider, using correct username.
+        // This username is stored in $user, which is supposed to be returned by our user provider.
+        $this->userService
+            ->expects($this->at(1))
+            ->method('loadUserByCredentials')
+            ->with($username, $password)
+            ->willReturn($apiUser);
+        $this->repository
+            ->expects($this->once())
+            ->method('setCurrentUser')
+            ->with($apiUser);
+
+        $method = new \ReflectionMethod($this->authProvider, 'checkAuthentication');
+        $method->setAccessible(true);
+        $method->invoke($this->authProvider, $user, $token);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Security\Core\Exception\BadCredentialsException
+     */
+    public function testCheckAuthenticationBadEmail()
+    {
+        $username = 'lolautruche';
+        $userEmail = 'jerome@code-rhapsodie.fr';
+        $password = 'foo';
+        $user = $this->createMock(User::class);
+        $user
+            ->method('getUsername')
+            ->willReturn($username);
+        $token = new UsernamePasswordToken($userEmail, $password, 'bar');
+
+        $this->configResolver
+            ->method('getParameter')
+            ->with('security.authentication_email.enabled', 'ez_core_extra')
+            ->willReturn(true);
+
+        // First call to UserService::loadUserByCredentials is done by original RepositoryAuthenticationProvider.
+        // It's supposed to fail since it's an email, and thus to thrown a BadCredentialsException.
+        $this->userService
+            ->expects($this->at(0))
+            ->method('loadUserByCredentials')
+            ->with($userEmail, $password)
+            ->willThrowException(new BadCredentialsException());
+        // 2nd call is done by our authentication provider, using correct username.
+        // This username is stored in $user, which is supposed to be returned by our user provider.
+        $this->userService
+            ->expects($this->at(1))
+            ->method('loadUserByCredentials')
+            ->with($username, $password)
+            ->willThrowException(new NotFoundException('Not found', 'User'));
+        $this->repository
+            ->expects($this->never())
+            ->method('setCurrentUser');
+
+        $method = new \ReflectionMethod($this->authProvider, 'checkAuthentication');
+        $method->setAccessible(true);
+        $method->invoke($this->authProvider, $user, $token);
+    }
+
+    /**
+     * @@expectedException \Symfony\Component\Security\Core\Exception\BadCredentialsException
+     */
+    public function testCheckAuthenticationEmailDisabled()
+    {
+        $username = 'lolautruche';
+        $userEmail = 'jerome@code-rhapsodie.fr';
+        $password = 'foo';
+        $user = $this->createMock(User::class);
+        $token = new UsernamePasswordToken($userEmail, $password, 'bar');
+
+        $this->configResolver
+            ->method('getParameter')
+            ->with('security.authentication_email.enabled', 'ez_core_extra')
+            ->willReturn(false);
+
+        $this->userService
+            ->expects($this->once())
+            ->method('loadUserByCredentials')
+            ->with($userEmail, $password)
+            ->willThrowException(new BadCredentialsException());
+        $this->repository
+            ->expects($this->never())
+            ->method('setCurrentUser');
+
+        $method = new \ReflectionMethod($this->authProvider, 'checkAuthentication');
+        $method->setAccessible(true);
+        $method->invoke($this->authProvider, $user, $token);
+    }
+}

--- a/Tests/Security/UserProviderTest.php
+++ b/Tests/Security/UserProviderTest.php
@@ -1,0 +1,138 @@
+<?php
+/*
+ * This file is part of the EzCoreExtraBundle package.
+ *
+ * @copyright Jérôme Vieilledent <jerome@vieilledent.fr>
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace Lolautruche\EzCoreExtraBundle\Tests\Security;
+
+use eZ\Publish\API\Repository\UserService;
+use eZ\Publish\Core\Repository\Values\User\User as APIUser;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use eZ\Publish\Core\MVC\Symfony\Security\User;
+use eZ\Publish\Core\MVC\Symfony\Security\User\APIUserProviderInterface;
+use Lolautruche\EzCoreExtraBundle\Security\UserProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
+
+class UserProviderTest extends TestCase
+{
+    /**
+     * @var MockObject|APIUserProviderInterface
+     */
+    private $innerProvider;
+
+    /**
+     * @var MockObject|UserService
+     */
+    private $userService;
+
+    /**
+     * @var MockObject|ConfigResolverInterface
+     */
+    private $configResolver;
+
+    /**
+     * @var UserProvider
+     */
+    private $userProvider;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->innerProvider = $this->createMock(APIUserProviderInterface::class);
+        $this->userService = $this->createMock(UserService::class);
+        $this->configResolver = $this->createMock(ConfigResolverInterface::class);
+        $this->userProvider = new UserProvider($this->innerProvider, $this->userService);
+        $this->userProvider->setConfigResolver($this->configResolver);
+    }
+
+    public function testLoadUserByUsername()
+    {
+        $user = new User();
+        $username = 'lolautruche';
+        $this->innerProvider
+            ->expects($this->once())
+            ->method('loadUserByUsername')
+            ->with($username)
+            ->willReturn($user);
+
+        $this->assertSame($user, $this->userProvider->loadUserByUsername($username));
+    }
+
+    public function testLoadUserByEmail()
+    {
+        $email = 'jerome@code-rhapsodie.fr';
+        $this->innerProvider
+            ->expects($this->once())
+            ->method('loadUserByUsername')
+            ->with($email)
+            ->willThrowException(new UsernameNotFoundException());
+        $this->configResolver
+            ->method('getParameter')
+            ->with('security.authentication_email.enabled', 'ez_core_extra')
+            ->willReturn(true);
+
+        $apiUser = $this->createMock(APIUser::class);
+        $apiUser->method('getUserId')->willReturn(1);
+        $user = new User($apiUser);
+        $this->userService
+            ->expects($this->once())
+            ->method('loadUsersByEmail')
+            ->with($email)
+            ->willReturn([$apiUser]);
+        $this->innerProvider
+            ->expects($this->once())
+            ->method('loadUserByAPIUser')
+            ->with($apiUser)
+            ->willReturn($user);
+
+        $this->assertSame($user, $this->userProvider->loadUserByUsername($email));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Security\Core\Exception\UsernameNotFoundException
+     */
+    public function testLoadUserEmailNotFound()
+    {
+        $email = 'foo@bar.com';
+        $this->innerProvider
+            ->expects($this->once())
+            ->method('loadUserByUsername')
+            ->with($email)
+            ->willThrowException(new UsernameNotFoundException());
+        $this->configResolver
+            ->method('getParameter')
+            ->with('security.authentication_email.enabled', 'ez_core_extra')
+            ->willReturn(true);
+        $this->userService
+            ->expects($this->once())
+            ->method('loadUsersByEmail')
+            ->with($email)
+            ->willReturn([]);
+
+        $this->userProvider->loadUserByUsername($email);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Security\Core\Exception\UsernameNotFoundException
+     */
+    public function testLoadUserEmailNotActivated()
+    {
+        $email = 'foo@bar.com';
+        $this->innerProvider
+            ->expects($this->once())
+            ->method('loadUserByUsername')
+            ->with($email)
+            ->willThrowException(new UsernameNotFoundException());
+        $this->configResolver
+            ->method('getParameter')
+            ->with('security.authentication_email.enabled', 'ez_core_extra')
+            ->willReturn(false);
+
+        $this->userProvider->loadUserByUsername($email);
+    }
+}


### PR DESCRIPTION
With this feature, any eZ user can authenticate by their username or email.
Original behavior (login with username) has precedence and fallbacks to email authentication
when needed (e.g. username authentication failed).

It's disabled by default and can be enabled per siteaccess:

```yaml
ez_core_extra:
    system:
        my_siteaccess:
            enable_email_authentication: true
```

> **Important note**: In order to correctly activate the feature, `EzCoreExtraBundle` **MUST** be instanciated **after eZ bundles** in `AppKernel`.

## TODO
- [x] Implement the feature
- [x] Add tests
- [x] Add documentation
- [x] Open a PR on `ezplatform-demo` to fix the bundle instanciation : https://github.com/ezsystems/ezplatform-demo/pull/90